### PR TITLE
Fix audio eMOS calculation and display

### DIFF
--- a/app/views/job_webhook_view.py
+++ b/app/views/job_webhook_view.py
@@ -22,6 +22,7 @@ from ..decorators import check_request_body
 from ..utils import JSONHttpResponse, clamp
 from ..logger import log
 
+
 def dictfetchall(cursor):
     """Return all rows from a cursor as a dict"""
 
@@ -31,6 +32,7 @@ def dictfetchall(cursor):
         for row in cursor.fetchall()
     ]
 
+
 # mapping between stats type and direction. we need for tracks
 keys = {
     'inbound-rtp': 'inbound',
@@ -39,6 +41,7 @@ keys = {
 
 # could not use GenericView. problem with rate limit: KeyError: 'REMOTE_ADDR'
 # class JobWebhookView(GenericView):
+
 
 class JobWebhookView(View):
 
@@ -98,13 +101,13 @@ class JobWebhookView(View):
         # save it again when done
         summary.save()
 
+    @staticmethod
     def get_stats_events(conference):
 
         try:
-            # use the native query because it's faster to handle the resulting payload
             with connection.cursor() as cursor:
                 cursor.execute(
-                    "SELECT * FROM app_genericevent WHERE conference_id = %s AND type = %s", 
+                    "SELECT * FROM app_genericevent WHERE conference_id = %s AND type = %s ORDER BY created_at ASC, id ASC",
                     [conference.id, 'stats']
                 )
 
@@ -113,26 +116,90 @@ class JobWebhookView(View):
         except Exception as e:
             log.warning('Native query for stats events failed. Using django ORM.')
 
-            # if it fails, use django's ORM
             events = EventView.query_events(
                 event_type='stats',
                 conference=conference,
-            )
+            ).order_by('created_at', 'id')
 
-            # transform into dicts so it's faster to handle
             events = [e.__dict__ for e in events]
 
         return events
 
     @staticmethod
+    def build_track_data(track_stats, direction, track_type):
+        """Pure helper that builds a summary track_data dict from raw track stats."""
+        track_data = {
+            'id': track_stats.get('id'),
+            'mediaType': track_stats.get('mediaType'),
+        }
+
+        if direction == 'inbound':
+            track_data['headerBytesReceived'] = track_stats.get('headerBytesReceived')
+            track_data['bytesReceived'] = track_stats.get('bytesReceived')
+            track_data['packetsReceived'] = track_stats.get('packetsReceived')
+            track_data['packetsLost'] = track_stats.get('packetsLost')
+            track_data['jitter'] = track_stats.get('jitter')
+
+        elif direction == 'outbound':
+            track_data['packetsSent'] = track_stats.get('packetsSent')
+            track_data['headerBytesSent'] = track_stats.get('headerBytesSent')
+            track_data['bytesSent'] = track_stats.get('bytesSent')
+
+        if track_type == 'video':
+            track_data['frameWidth'] = track_stats.get('frameWidth')
+            track_data['frameHeight'] = track_stats.get('frameHeight')
+
+            if direction == 'inbound':
+                track_data['framesReceived'] = track_stats.get('framesReceived')
+                track_data['framesDecoded'] = track_stats.get('framesDecoded')
+                track_data['totalDecodeTime'] = track_stats.get('totalDecodeTime')
+
+            elif direction == 'outbound':
+                track_data['framesSent'] = track_stats.get('framesSent')
+                track_data['framesEncoded'] = track_stats.get('framesEncoded')
+                track_data['totalEncodeTime'] = track_stats.get('totalEncodeTime')
+
+        return track_data
+
+    @staticmethod
+    def _append_track_event(event_data, response_object, connection_id):
+        """Append a per-track event to the latest snapshot for this connection."""
+        if connection_id not in response_object or not response_object[connection_id]:
+            return False
+
+        snapshot = response_object[connection_id][-1]
+        remote = snapshot['data']['remote']
+
+        emos_score = None
+        try:
+            emos_score = JobWebhookView.compute_emos(event_data, remote)
+        except Exception as e:
+            log.error(f'Error while processing data for eMOS score: {e}')
+
+        track_kind = event_data.get('kind')
+        track_direction = keys.get(event_data.get('type'))
+
+        track_data = JobWebhookView.build_track_data(
+            event_data, track_direction, track_kind)
+
+        if track_direction == 'inbound':
+            track_data['emos'] = emos_score
+
+        try:
+            snapshot['data'][track_kind][track_direction].append(track_data)
+        except (KeyError, TypeError):
+            pass
+
+        return True
+
+    @staticmethod
     def v1_summary(conference):
         events = JobWebhookView.get_stats_events(conference)
 
-        # response object that will be encoded and returned
         response_object = {}
+        pending_tracks = {}
 
         events = list(events)
-        events.reverse()
 
         for event in events:
             connection_id = str(event.get('connection_id'))
@@ -141,10 +208,9 @@ class JobWebhookView(View):
             if event_data.get('connection'):
                 connection_data = event_data.get('connection')
 
-                # log.info('adding connection {}'.format(connection_id))
                 response_object[connection_id] = response_object.get(connection_id, [])
 
-                response_object[connection_id].append({
+                snapshot = {
                     'id': str(event.get('id')),
                     'app': str(event.get('app_id')),
                     'session': str(event.get('session_id')),
@@ -172,58 +238,42 @@ class JobWebhookView(View):
                             'outbound': []
                         }
                     }
-                })
-
-            if event_data.get('track'):
-
-                emos_score = None
-                try:
-                    emos_score = JobWebhookView.compute_emos(event_data, response_object[connection_id][-1]['data']['remote'])
-                except Exception as e:
-                    log.error(f'Error while processing data for eMOS score: {e}')
-                    pass
-
-                track_kind = event_data.get('kind')
-                track_direction = keys.get(event_data.get('type'))
-
-                track_data = {
-                    'id': event_data.get('id'), 
-                    'mediaType': event_data.get('mediaType'),
                 }
 
-                if track_direction == 'inbound':
-                    track_data['headerBytesReceived'] = event_data.get('headerBytesReceived')
-                    track_data['bytesReceived'] = event_data.get('bytesReceived')
-                    track_data['packetsReceived'] = event_data.get('packetsReceived')
-                    track_data['packetsLost'] = event_data.get('packetsLost')
-                    track_data['jitter'] = event_data.get('jitter')
-                    track_data['emos'] = emos_score
+                remote = event_data.get('remote', {})
 
-                elif track_direction == 'outbound':
-                    track_data['packetsSent'] = event_data.get('packetsSent')
-                    track_data['headerBytesSent'] = event_data.get('headerBytesSent')
-                    track_data['bytesSent'] = event_data.get('bytesSent')
+                for track_type in ['audio', 'video']:
+                    for direction in ['inbound', 'outbound']:
+                        inline_tracks = event_data.get(track_type, {}).get(direction, [])
+                        for track_stats in inline_tracks:
+                            track_data = JobWebhookView.build_track_data(
+                                track_stats, direction, track_type)
 
-                if track_kind == 'video':
-                    track_data['frameWidth'] = event_data.get('frameWidth')
-                    track_data['frameHeight'] = event_data.get('frameHeight')
+                            if track_type == 'audio' and direction == 'inbound':
+                                try:
+                                    emos_score = JobWebhookView.compute_emos(
+                                        track_stats, remote)
+                                except Exception as e:
+                                    log.error(f'Error computing eMOS for inline track: {e}')
+                                    emos_score = None
+                                track_data['emos'] = emos_score
 
-                    if track_direction == 'inbound':
-                        track_data['framesReceived'] = event_data.get('framesReceived')
-                        track_data['framesDecoded'] = event_data.get('framesDecoded')
-                        track_data['totalDecodeTime'] = event_data.get('totalDecodeTime')
+                            snapshot['data'][track_type][direction].append(track_data)
 
-                    elif track_direction == 'outbound':
-                        track_data['framesSent'] = event_data.get('framesSent')
-                        track_data['framesEncoded'] = event_data.get('framesEncoded')
-                        track_data['totalEncodeTime'] = event_data.get('totalEncodeTime')
+                response_object[connection_id].append(snapshot)
 
-                try:
-                    response_object[connection_id][-1]['data'][track_kind][track_direction].append(track_data)
-                except Exception as e:
-                    pass
+                # Flush any track events that arrived before this snapshot
+                for pending_event_data in pending_tracks.pop(connection_id, []):
+                    JobWebhookView._append_track_event(
+                        pending_event_data, response_object, connection_id)
 
-        # concatenate arrays
+            if 'track' in event_data:
+                if connection_id in response_object and response_object[connection_id]:
+                    JobWebhookView._append_track_event(
+                        event_data, response_object, connection_id)
+                else:
+                    pending_tracks.setdefault(connection_id, []).append(event_data)
+
         final = []
         for a in response_object.values():
             final += a
@@ -233,98 +283,98 @@ class JobWebhookView(View):
     @staticmethod
     def compute_emos(event_data, remote):
 
-        # we only care about track data
-        if event_data.get('track'):
+        if 'track' not in event_data:
+            return None
 
-            track_kind = event_data.get('kind')
-            track_direction = keys.get(event_data.get('type'))
-            track_id = event_data.get('id')
+        track_kind = event_data.get('kind')
+        track_direction = keys.get(event_data.get('type'))
+        track_id = event_data.get('id')
 
-            # if audio
-            if track_kind == 'audio':
+        if track_kind != 'audio' or track_direction != 'inbound':
+            return None
 
-                # if inbound
-                if track_direction == 'inbound':
+        packets_received = event_data.get('packetsReceived', 0) or 0
+        packets_lost = event_data.get('packetsLost', 0) or 0
+        total_packets = packets_received + packets_lost
 
-                    packetloss = None
-                    round_trip_time = None
+        if total_packets == 0:
+            return None
 
-                    tracks = remote.get('audio', {}).get('outbound', [])
-                    outbound_audio_track = [t for t in tracks if t.get('localId') == track_id]
+        # Prefer remote-outbound-rtp packetsSent for packet loss (more accurate),
+        # fall back to local packetsLost / (packetsLost + packetsReceived)
+        packetloss = None
+        outbound_tracks = remote.get('audio', {}).get('outbound', [])
+        outbound_match = [t for t in outbound_tracks if t.get('localId') == track_id]
 
-                    # if we have remote stats
-                    if len(outbound_audio_track) == 1:
-                        # rtt is in seconds
-                        round_trip_time = outbound_audio_track[0].get('roundTripTime', 0) * 1000
+        if len(outbound_match) == 1:
+            packets_sent = outbound_match[0].get('packetsSent')
+            if packets_sent is not None and packets_sent > 0:
+                packetloss = max((packets_sent - packets_received) / packets_sent, 0)
 
-                        packets_sent = outbound_audio_track[0].get('packetsSent')
-                        packets_received = event_data.get('packetsReceived')
+        if packetloss is None:
+            packetloss = packets_lost / total_packets
 
-                        # make sure we have packets_sent
-                        if packets_sent is not None:
-                            packetloss = (packets_sent - packets_received) / packets_sent
-                            packetloss = max(packetloss, 0)
-                        else:
-                            # without we can just return
-                            return None
+        # RTT from remote-inbound-rtp (carries roundTripTime, unlike remote-outbound-rtp)
+        round_trip_time = 0
+        for rit in remote.get('audio', {}).get('inbound', []):
+            if rit.get('roundTripTime') is not None:
+                round_trip_time = rit.get('roundTripTime') * 1000
+                break
 
-                    else:
-                        # without remote track no need to continue
-                        return None
+        buffer_delay = 0
+        emitted_count = event_data.get('jitterBufferEmittedCount')
+        jitter_delay = event_data.get('jitterBufferDelay')
+        if emitted_count is not None and jitter_delay is not None and emitted_count > 0:
+            buffer_delay = (jitter_delay / emitted_count) * 1000
 
-                    buffer_delay = 0
-                    if event_data.get('jitterBufferEmittedCount') is not None and event_data.get('jitterBufferDelay') is not None:
-                        buffer_delay = ( event_data.get('jitterBufferDelay') / event_data.get('jitterBufferEmittedCount') ) * 1000
+        # E-model expects one-way mouth-to-ear delay
+        delay = 20 + buffer_delay + (round_trip_time / 2)
 
-                    delay = 20 + buffer_delay + round_trip_time
+        r0 = 100
 
-                    r0 = 100
+        Ie = 6
+        bitrate = event_data.get('bitrate')
+        if bitrate and bitrate > 0:
+            Ie = clamp(55 - 4.6 * math.log(bitrate), 0, 30)
 
-                    # TODO: add dtx detection
-                    Ie = 6
-                    if event_data.get('bitrate'):
-                        Ie = clamp(55 - 4.6 * math.log(event_data.get('bitrate')), 0, 30)
+        Bpl = 20 if event_data.get('fecPacketsReceived') else 10
+        Ipl = Ie + (100 - Ie) * (packetloss / (packetloss + Bpl))
 
-                    Bpl = 20 if event_data.get('fecPacketsReceived') else 10
-                    Ipl = Ie + (100 - Ie) * (packetloss / (packetloss + Bpl))
+        aux = 0.1 * (delay - 150) if delay > 150 else 0
+        Id = delay * 0.03 + aux
 
-                    aux = 0.1 * delay - 150 if delay > 150 else 0
-                    Id = delay * 0.03 + aux
+        R = clamp(r0 - Ipl - Id, 0, 100)
 
-                    R = clamp(r0 - Ipl - Id, 0, 100)
+        MOS = 1 + 0.035 * R + (R * (R - 60) * (100 - R) * 7) / 1000000
 
-                    MOS = 1 + 0.035 * R + (R * (R - 60) * (100 - R) * 7) / 1000000
-
-                    return clamp(round(MOS * 100) / 100, 1, 5)
-
+        return clamp(round(MOS * 100) / 100, 1, 5)
 
     @staticmethod
     def check_emos_score(summary):
         """
         Used to check if the participant / conference had problems due to low emos
         and save an issue if so
-
-        TODO: refactor this function. not very pretty :\
         """
+
+        def make_issue_template():
+            return {
+                'audio': {
+                    'session': None,
+                    'conference': None,
+                    'count': 0,
+                    'average': 0
+                },
+                'video': {
+                    'session': None,
+                    'conference': None,
+                    'count': 0,
+                    'average': 0
+                }
+            }
 
         issues = {
             'low': {},
             'very_low': {},
-        }
-
-        issue_template = {
-            'audio': {
-                'session': None,
-                'conference': None,
-                'count': 0,
-                'average': 0
-            },
-            'video': {
-                'session': None,
-                'conference': None,
-                'count': 0,
-                'average': 0
-            }
         }
 
         # if an emos score was detected for more than 30 seconds
@@ -332,46 +382,34 @@ class JobWebhookView(View):
 
         def update_score(issue, score):
             issue['count'] += 1
-
-            if not issue['average']:
-                issue['average'] = score
-
-            issue['average'] = (issue['average'] + score) / 2
+            # Welford's online mean
+            issue['average'] = issue['average'] + (score - issue['average']) / issue['count']
 
             issue['session'] = report.get('session')
             issue['conference'] = report.get('conference')
 
-
         for report in summary:
-            inbound_audio = report.get('data').get('audio').get('inbound')
-            
-            # check all inbound audio tracks eMOS
+            inbound_audio = report.get('data', {}).get('audio', {}).get('inbound', [])
+
             for track in inbound_audio:
                 score = track.get('emos')
                 participant_id = report.get('participant')
-                
-                # if we've computed the score
+
                 if not score:
                     continue
 
-                # if the score is bellow 3 = really bad exp
                 if score < 3:
-                    issue = issues['very_low'].get(participant_id, issue_template)
+                    if participant_id not in issues['very_low']:
+                        issues['very_low'][participant_id] = make_issue_template()
 
-                    update_score(issue['audio'], score)
+                    update_score(issues['very_low'][participant_id]['audio'], score)
 
-                    issues['very_low'][participant_id] = issue
-
-                # bellow 4 is not ideal
                 elif score < 4:
-                    issue = issues['low'].get(participant_id, issue_template)
+                    if participant_id not in issues['low']:
+                        issues['low'][participant_id] = make_issue_template()
 
-                    update_score(issue['audio'], score)
+                    update_score(issues['low'][participant_id]['audio'], score)
 
-                    issues['low'][participant_id] = issue
-
-
-        # loop through issues and see if participants had prolonged problems
         for participant_id, issue in issues['low'].items():
             if issue['audio']['count'] >= min_score:
                 Issue(


### PR DESCRIPTION
Summary

- **Fix `v1_summary` to extract inline audio inbound tracks from main events** — inbound audio tracks were embedded inline on main stat events but never iterated over, so `compute_emos` was never called for them. Added `build_track_data` helper and loop over inline tracks per snapshot.
- **Fix `compute_emos` packet loss fallback** — previously required `remote-outbound-rtp` data (which many browsers don't send) for `packetsSent`. Now falls back to `packetsLost / (packetsLost + packetsReceived)` from local `inbound-rtp` stats when remote data is unavailable.
- **Fix `compute_emos` RTT source** — changed RTT lookup from `remote.audio.outbound` (which never carries `roundTripTime`) to `remote.audio.inbound`.
- **Fix `compute_emos` one-way delay** — changed `delay = RTT` to `delay = RTT / 2` per E-model specification.
- **Fix `compute_emos` guards** — added `bitrate 0` guard before `math.log`, `packets_sent 0` and `total_packets == 0` guards, and fixed operator precedence in auxiliary delay (`0.1 * (delay - 150)`).
- **Fix `check_emos_score` shared mutable state** — replaced shared `issue_template` dict with a `make_issue_template()` factory function to prevent cross-participant corruption.
- **Fix `check_emos_score` running average** — replaced incorrect `(avg + score) / 2` with Welford's online mean.
- **Fix event ordering** — added `ORDER BY created_at ASC, id ASC` to `get_stats_events` and removed `events.reverse()`.
- **Add pending track buffer** — per-track events that arrive before their connection's main event are queued and flushed when the snapshot is created.
- **Add `@staticmethod` to `get_stats_events`**.

Test plan
- [x] Verified eMOS scores computed for Chrome and Edge participants across multiple test calls
- [x] Verified packet loss fallback produces correct scores when `remote-outbound-rtp` is absent
- [x] Verified zero errors in API logs during summary building
- [x] Verified `check_emos_score` correctly accumulates per-participant averages