### PR TITLE
fix: use request.META for REMOTE_ADDR fallback in get_client_ip

### DIFF
--- a/app/utils.py
+++ b/app/utils.py
@@ -271,7 +271,7 @@ def get_client_ip(request):
     if x_forwarded_for:
         ip = x_forwarded_for.split(',')[0]
     else:
-        ip = request.headers.get('Remote-Addr')
+        ip = request.META.get('REMOTE_ADDR')
     return ip
 
 


### PR DESCRIPTION
## Summary

- `request.headers` does not expose WSGI environ variables — `REMOTE_ADDR` lives in `request.META`, not in HTTP headers
- When `X-Forwarded-For` is absent, `request.headers.get('Remote-Addr')` silently returns `None`, causing the GeoIP lookup to be skipped entirely and leaving `geo_ip.city` and `geo_ip.country_code` as `null`
- This explains why two participants joining from the same IP can have different location results depending on which code path handled their request
- Fix: use `request.META.get('REMOTE_ADDR')` as the fallback

## Test plan

- [ ] Join a conference session without a load balancer / without `X-Forwarded-For` header
- [ ] Confirm the participant's session now has non-null `geo_ip` data
- [ ] Confirm participants behind a load balancer (with `X-Forwarded-For`) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)