### PR TITLE
fix: add gunicorn config with dynamic worker count

### DIFF
--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -5,4 +5,15 @@ workers = int(os.environ.get('GUNICORN_WORKERS', multiprocessing.cpu_count() * 2
 threads = 2
 worker_class = 'gthread'
 timeout = 30
+graceful_timeout = 30
 bind = '0.0.0.0:8081'
+
+preload_app = True
+
+max_requests = 1000
+max_requests_jitter = 50
+
+accesslog = '-'
+errorlog = '-'
+
+worker_tmp_dir = '/dev/shm'


### PR DESCRIPTION
## Summary

- API was running with 1 gunicorn sync worker (the default when no config is provided)
- During peak traffic, all active sessions send `POST /v1/stats` simultaneously — the single worker queues up, hits the 30s timeout, and clients get 499/500/502
- Observed: ~25,950 × 499 and ~4,004 × 500 errors in a 2-hour window
- Fix: add `gunicorn.conf.py` so gunicorn picks up proper worker/thread settings on startup

## What DevOps needs to do

Add `GUNICORN_WORKERS=3` as an environment variable in the ECS task definition for `sh-jitsi-prod-pm-api-use1-task`, then redeploy the service.

If CPU is scaled up later, update `GUNICORN_WORKERS` using: `(vCPUs × 2) + 1`

## Config

| Setting | Value |
|---|---|
| `workers` | From `GUNICORN_WORKERS` env var, falls back to `(cpu_count × 2) + 1` |
| `threads` | `2` (hardcoded) |
| `worker_class` | `gthread` |
| `timeout` | `30s` |

## Test plan

- [ ] Deploy with `GUNICORN_WORKERS=3` set in ECS task definition
- [ ] Confirm gunicorn logs show `workers: 3` on startup in CloudWatch
- [ ] Monitor `/ecs/sh-jitsi-peermetrics-api-prod` — 499/500 count should drop significantly

🤖 Generated with [Claude Code](https://claude.com/claude-code)