### PR TITLE
fix: use real client IP for rate limiting instead of ALB IP

### DIFF
--- a/app/views/generic_view.py
+++ b/app/views/generic_view.py
@@ -7,10 +7,10 @@ from ..logger import log
 
 
 def get_real_ip(group, request):
-    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
-    if x_forwarded_for:
-        return x_forwarded_for.split(',')[0].strip()
-    return request.META.get('REMOTE_ADDR', '')
+    return (
+        request.META.get('HTTP_X_REAL_IP')
+        or request.META.get('REMOTE_ADDR', '')
+    ).strip()
 
 
 class Logger(object):


### PR DESCRIPTION
## Summary

- `django-ratelimit`'s `'ip'` key uses `request.META['REMOTE_ADDR']`, which behind an ALB is always the load balancer's private IP (`10.10.0.184` or `10.10.1.101`)
- This caused **ALL clients across ALL sessions** to share a single rate limit bucket of 2000 req/min
- Once exhausted, every request got **429 Too Many Requests** — 672,000 rejected requests in one hour
- Adding more workers / vCPUs did not help because the rate limiter rejects requests at the Django level before view code runs

## Fix

Replaced `ratelimit_key = 'ip'` with a custom function that extracts the real client IP from the `X-Forwarded-For` header (set by the ALB):

```python
def get_real_ip(group, request):
    x_forwarded_for = request.META.get('HTTP_X_FORWARDED_FOR')
    if x_forwarded_for:
        return x_forwarded_for.split(',')[0].strip()
    return request.META.get('REMOTE_ADDR', '')
```

Now each real client gets its own 2000 req/min bucket.

## Test plan

- [ ] Verified locally: requests with different `X-Forwarded-For` values get separate rate limit buckets
- [ ] After deploy, 429 errors should stop immediately
- [ ] Monitor CloudWatch: `/v1/stats` and `/v1/issues` should return 200 instead of 429