### PR TITLE
fix: annotate conference list with has_errors, has_warnings, participants_count

### DIFF
--- a/app/views/conference_view.py
+++ b/app/views/conference_view.py
@@ -1,13 +1,14 @@
 import datetime
 
 from django.core.exceptions import ValidationError
-from django.db.models import Count, Exists, OuterRef
+from django.db.models import Count, Exists, IntegerField, OuterRef, Subquery
 
 from ..errors import (INVALID_PARAMETERS, CONFERENCE_NOT_FOUND,
                       MISSING_PARAMETERS, PMError)
 from ..utils import JSONHttpResponse, serialize, paginate_and_serialize
 from ..models.conference import Conference
 from ..models.issue import Issue
+from ..models.participant import Participant
 from .generic_view import GenericView
 
 class ConferencesView(GenericView):
@@ -49,7 +50,14 @@ class ConferencesView(GenericView):
                 has_warnings=Exists(
                     Issue.objects.filter(conference=OuterRef('pk'), type='w', is_active=True)
                 ),
-                participants_count=Count('participants', distinct=True),
+                participants_count=Subquery(
+                    Participant.objects.filter(
+                        conferences=OuterRef('pk')
+                    ).order_by().values('conferences').annotate(
+                        cnt=Count('id', distinct=True)
+                    ).values('cnt')[:1],
+                    output_field=IntegerField(),
+                ),
             )
         except ValidationError:
             raise PMError(status=400, app_error=INVALID_PARAMETERS)

--- a/app/views/conference_view.py
+++ b/app/views/conference_view.py
@@ -52,7 +52,8 @@ class ConferencesView(GenericView):
                 ),
                 participants_count=Subquery(
                     Participant.objects.filter(
-                        conferences=OuterRef('pk')
+                        conferences=OuterRef('pk'),
+                        is_active=True,
                     ).order_by().values('conferences').annotate(
                         cnt=Count('id', distinct=True)
                     ).values('cnt')[:1],

--- a/app/views/conference_view.py
+++ b/app/views/conference_view.py
@@ -1,11 +1,13 @@
 import datetime
 
 from django.core.exceptions import ValidationError
+from django.db.models import Count, Exists, OuterRef
 
 from ..errors import (INVALID_PARAMETERS, CONFERENCE_NOT_FOUND,
                       MISSING_PARAMETERS, PMError)
 from ..utils import JSONHttpResponse, serialize, paginate_and_serialize
 from ..models.conference import Conference
+from ..models.issue import Issue
 from .generic_view import GenericView
 
 class ConferencesView(GenericView):
@@ -40,12 +42,23 @@ class ConferencesView(GenericView):
             filters['created_at__gt'] = datetime.datetime.fromisoformat(filters.get('created_at__gt'))
 
         try:
-            objs = Conference.filter(**filters)
+            objs = Conference.filter(**filters).annotate(
+                has_errors=Exists(
+                    Issue.objects.filter(conference=OuterRef('pk'), type='e', is_active=True)
+                ),
+                has_warnings=Exists(
+                    Issue.objects.filter(conference=OuterRef('pk'), type='w', is_active=True)
+                ),
+                participants_count=Count('participants', distinct=True),
+            )
         except ValidationError:
             raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
         return JSONHttpResponse(
-            content=paginate_and_serialize(request, objs),
+            content=paginate_and_serialize(
+                request, objs,
+                properties=['has_errors', 'has_warnings', 'participants_count'],
+            ),
         )
 
     @classmethod


### PR DESCRIPTION
## Problem

After expand_fields was removed from the conference list (PR #19), the dashboard lost:
- Error/warning icons on the conference list
- Participant count data for the "Number of participants" chart (shows all zeros)

## Fix

Annotate the conference queryset with lightweight fields computed in the same SQL query:

```python
objs = Conference.filter(**filters).annotate(
    has_errors=Exists(Issue.objects.filter(conference=OuterRef('pk'), type='e')),
    has_warnings=Exists(Issue.objects.filter(conference=OuterRef('pk'), type='w')),
    participants_count=Count('participants', distinct=True),
)
```

No N+1 queries — all computed as subqueries/aggregations in one query.

## API response

```json
{
  "conference_id": "sessionshealth-abc123",
  "has_errors": false,
  "has_warnings": true,
  "participants_count": 2,
  ...
}
```

## Test plan

- [ ] Conference list shows error/warning icons
- [ ] "Number of participants" chart shows correct counts instead of zeros
- [ ] Verified locally: `participants_count=2` in API response