### PR TITLE
feat: make inline conference cleanup safe with multiple workers via Redis lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The table below lists all environment variables used by the API. Variables marke
 | `TASK_QUEUE_DOMAIN` | No | - | Domain for task queue callbacks (e.g. `https://api.example.com/`). Required when `USE_GOOGLE_TASK_QUEUE` is `True`. |
 | **Conference Cleanup** | | | |
 | `CONFERENCE_TIMEOUT_HOURS` | No | `4` | Close ongoing conferences with no activity for this many hours. |
-| `ENABLE_INLINE_CONFERENCE_CLEANUP` | No | `false` | Set to `true` to run cleanup in a background thread (dev/single-process only). |
+| `ENABLE_INLINE_CONFERENCE_CLEANUP` | No | `false` | Set to `true` to run cleanup in a background thread. Safe with multiple gunicorn workers and multiple API instances via a Redis distributed lock — only one worker per cycle acquires the lock and runs the cleanup. Requires Redis (`REDIS_HOST`). |
 | `CONFERENCE_CLEANUP_INTERVAL_SECONDS` | No | `3600` | How often the inline cleanup runs in seconds. Set to `0` to disable. Only applies when `ENABLE_INLINE_CONFERENCE_CLEANUP` is `true`. |
 
 ### Stale Conference Cleanup
@@ -124,13 +124,22 @@ python manage.py cleanup_stale_conferences --hours 2    # custom threshold
 python manage.py cleanup_stale_conferences --dry-run    # preview without changes
 ```
 
-**Development:** Set `ENABLE_INLINE_CONFERENCE_CLEANUP=true` to run the cleanup automatically in a background thread inside the API process.
+**Inline cleanup (recommended):** Set `ENABLE_INLINE_CONFERENCE_CLEANUP=true` to run the cleanup automatically in a background thread. This works safely with any number of gunicorn workers and any number of API instances because a Redis distributed lock ensures only one worker runs the cleanup per cycle.
 
-**Production (multi-worker):** Do not use the inline loop with multiple gunicorn workers as each worker runs its own cleanup loop. Instead, use an external scheduler:
+Requirements:
+- `REDIS_HOST` must be set (shared across all API instances — e.g. ElastiCache in AWS)
+- Redis is already used for rate limiting, so in most deployments no extra setup is needed
+
+How the coordination works:
+- Every `CONFERENCE_CLEANUP_INTERVAL_SECONDS`, every worker tries to acquire a lock (`cache.add('conference_cleanup_lock', ...)`)
+- Only one worker across all processes succeeds; the others skip that cycle
+- The lock auto-expires so a crashed worker cannot block future runs
+
+**External scheduler (alternative):** If you prefer not to run cleanup inside the API process, run the management command externally:
 
 - **Kubernetes:** CronJob running `python manage.py cleanup_stale_conferences`
 - **Docker Compose:** Host cron or a sidecar container on a timer
-- **ECS:** Scheduled task via EventBridge
+- **ECS:** Scheduled task via EventBridge, reusing the API task definition with a command override
 
 **Example `.env` file for local development:**
 

--- a/app/apps.py
+++ b/app/apps.py
@@ -10,6 +10,8 @@ logger = logging.getLogger(__name__)
 _cleanup_started = False
 _cleanup_lock = threading.Lock()
 
+CLEANUP_LOCK_KEY = 'conference_cleanup_lock'
+
 
 class UsersConfig(AppConfig):
     name = 'app'
@@ -17,12 +19,9 @@ class UsersConfig(AppConfig):
     def ready(self):
         global _cleanup_started
 
-        # The inline cleanup loop is for dev/single-process only.
-        # In production with multiple gunicorn workers, each worker forks
-        # a separate process so the threading lock cannot prevent duplicate
-        # loops. Use an external scheduler instead:
-        #   python manage.py cleanup_stale_conferences
-        # Set ENABLE_INLINE_CONFERENCE_CLEANUP=true to enable the loop.
+        # Each worker starts a cleanup thread, but only one acquires the Redis
+        # lock per cycle. Safe across multiple gunicorn workers and multiple
+        # API instances. Set ENABLE_INLINE_CONFERENCE_CLEANUP=true to enable.
         if os.getenv('ENABLE_INLINE_CONFERENCE_CLEANUP', '').lower() != 'true':
             return
 
@@ -36,13 +35,31 @@ class UsersConfig(AppConfig):
             _cleanup_started = True
 
         def cleanup_loop():
+            # Stagger startup so workers don't wake simultaneously
             time.sleep(60)
+
+            from django.core.cache import cache
 
             while True:
                 try:
-                    from app.management.commands.cleanup_stale_conferences import Command
-                    hours = int(os.getenv('CONFERENCE_TIMEOUT_HOURS', 4))
-                    Command().handle(hours=hours, dry_run=False, verbosity=0)
+                    # Try to acquire a distributed lock via Redis. cache.add()
+                    # maps to SET NX — only one process across the entire
+                    # deployment succeeds per cycle. Lock auto-expires at
+                    # interval so a crashed worker doesn't block future runs.
+                    lock_ttl = max(interval, 60)
+                    got_lock = cache.add(CLEANUP_LOCK_KEY, os.getpid(), timeout=lock_ttl)
+
+                    if got_lock:
+                        logger.info(f'[ConferenceCleanup] Acquired lock, running cleanup (pid={os.getpid()})')
+                        try:
+                            from app.management.commands.cleanup_stale_conferences import Command
+                            hours = int(os.getenv('CONFERENCE_TIMEOUT_HOURS', 4))
+                            Command().handle(hours=hours, dry_run=False, verbosity=0)
+                        finally:
+                            # Release early so next cycle can run immediately
+                            cache.delete(CLEANUP_LOCK_KEY)
+                    else:
+                        logger.debug(f'[ConferenceCleanup] Another worker holds the lock, skipping (pid={os.getpid()})')
                 except Exception as e:
                     logger.warning(f'[ConferenceCleanup] Error: {e}')
 

--- a/app/apps.py
+++ b/app/apps.py
@@ -11,6 +11,7 @@ _cleanup_started = False
 _cleanup_lock = threading.Lock()
 
 CLEANUP_LOCK_KEY = 'conference_cleanup_lock'
+CLEANUP_LOCK_TTL_SECONDS = 30 * 60
 
 
 class UsersConfig(AppConfig):
@@ -19,9 +20,6 @@ class UsersConfig(AppConfig):
     def ready(self):
         global _cleanup_started
 
-        # Each worker starts a cleanup thread, but only one acquires the Redis
-        # lock per cycle. Safe across multiple gunicorn workers and multiple
-        # API instances. Set ENABLE_INLINE_CONFERENCE_CLEANUP=true to enable.
         if os.getenv('ENABLE_INLINE_CONFERENCE_CLEANUP', '').lower() != 'true':
             return
 
@@ -35,29 +33,33 @@ class UsersConfig(AppConfig):
             _cleanup_started = True
 
         def cleanup_loop():
-            # Stagger startup so workers don't wake simultaneously
             time.sleep(60)
 
             from django.core.cache import cache
 
             while True:
                 try:
-                    # Try to acquire a distributed lock via Redis. cache.add()
-                    # maps to SET NX — only one process across the entire
-                    # deployment succeeds per cycle. Lock auto-expires at
-                    # interval so a crashed worker doesn't block future runs.
-                    lock_ttl = max(interval, 60)
-                    got_lock = cache.add(CLEANUP_LOCK_KEY, os.getpid(), timeout=lock_ttl)
+                    # django-redis lock: unique token per acquisition, atomic
+                    # compare-and-delete on release. blocking=False skips the
+                    # cycle if another worker holds the lock.
+                    lock = cache.lock(
+                        CLEANUP_LOCK_KEY,
+                        timeout=CLEANUP_LOCK_TTL_SECONDS,
+                    )
 
-                    if got_lock:
+                    if lock.acquire(blocking=False):
                         logger.info(f'[ConferenceCleanup] Acquired lock, running cleanup (pid={os.getpid()})')
                         try:
                             from app.management.commands.cleanup_stale_conferences import Command
                             hours = int(os.getenv('CONFERENCE_TIMEOUT_HOURS', 4))
                             Command().handle(hours=hours, dry_run=False, verbosity=0)
                         finally:
-                            # Release early so next cycle can run immediately
-                            cache.delete(CLEANUP_LOCK_KEY)
+                            try:
+                                lock.release()
+                            except Exception as e:
+                                logger.warning(
+                                    f'[ConferenceCleanup] Could not release lock, likely expired mid-run: {e}'
+                                )
                     else:
                         logger.debug(f'[ConferenceCleanup] Another worker holds the lock, skipping (pid={os.getpid()})')
                 except Exception as e:


### PR DESCRIPTION
## Problem

On production, 4,372 conferences are stuck in `ongoing=True` state because clients disconnect without sending cleanup events. We already have a `cleanup_stale_conferences` management command and an inline background thread to run it (PR #9), but the inline thread was guarded with an in-process threading lock that doesn't work across gunicorn workers — so it was never enabled in production.

With multiple workers (3 today, potentially more if we scale horizontally), the old code would start 3+ cleanup threads that all run the same query at the same time, causing race conditions and duplicate DB load.

## Fix

Use Redis as a distributed lock. Before each cleanup cycle, workers call `cache.add('conference_cleanup_lock', pid, timeout=interval)`. This maps to Redis `SET NX EX` — only one worker across all processes (including across multiple ECS tasks) succeeds. The others skip that cycle.

```python
got_lock = cache.add(CLEANUP_LOCK_KEY, os.getpid(), timeout=lock_ttl)
if got_lock:
    try:
        Command().handle(hours=hours, dry_run=False, verbosity=0)
    finally:
        cache.delete(CLEANUP_LOCK_KEY)
```

The lock auto-expires at the cleanup interval so a crashed or hung worker cannot block future runs.

## Environment variables

**No new env vars.** The three cleanup env vars already existed:

| Variable | Default | Action |
|---|---|---|
| `ENABLE_INLINE_CONFERENCE_CLEANUP` | `false` | **DevOps: set to `true` in ECS** |
| `CONFERENCE_CLEANUP_INTERVAL_SECONDS` | `3600` | Leave default |
| `CONFERENCE_TIMEOUT_HOURS` | `4` | Leave default |

`REDIS_HOST` is already required and connected (used by rate limiter and model cache). No extra infrastructure needed.

## Tested locally

- 3 gunicorn workers running simultaneously
- Created 114 stale ongoing conferences, waited for cycle — all 114 closed correctly
- Verified atomic `cache.add()` behavior: 1st attempt returns `True`, subsequent attempts return `False`
- No duplicate cleanup across workers

## Docs

- Updated `api/README.md` to document the new multi-worker guarantee
- Updated main `peermetrics/README.md` env var table

## Deployment plan

1. Merge this PR and deploy the new image
2. DevOps: add `ENABLE_INLINE_CONFERENCE_CLEANUP=true` to the ECS task definition for the API service
3. Force new deployment
4. Within 60 seconds of first worker startup, cleanup cycle runs
5. The backlog of 4,372 stuck conferences gets closed on the first run