### PR TITLE
feat: conferences summary endpoint + indexes (Phase 0 + Phase 1 of #20)

### DIFF
--- a/app/migrations/0004_dashboard_indexes.py
+++ b/app/migrations/0004_dashboard_indexes.py
@@ -1,0 +1,44 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    """
+    Phase 0 indexes for the dashboard aggregation work (#20).
+
+    Targets the queries run by the new /v1/conferences/summary endpoint
+    and similar time-range dashboard queries:
+
+    - conference(app_id, created_at): filter + GROUP BY for the summary
+    - issue(conference_id, type): speeds up the EXISTS subqueries that
+      classify conferences as has_error / has_warning
+    - app_genericevent(app_id, created_at): future summary endpoints that
+      group events by day (also helps cleanup_stale_conferences)
+    """
+
+    dependencies = [
+        ('app', '0003_conference_unique_together'),
+    ]
+
+    operations = [
+        migrations.AddIndex(
+            model_name='conference',
+            index=models.Index(
+                fields=['app', '-created_at'],
+                name='idx_conf_app_created',
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='issue',
+            index=models.Index(
+                fields=['conference', 'type'],
+                name='idx_issue_conf_type',
+            ),
+        ),
+        migrations.AddIndex(
+            model_name='genericevent',
+            index=models.Index(
+                fields=['app', '-created_at'],
+                name='idx_genevent_app_created',
+            ),
+        ),
+    ]

--- a/app/models/conference.py
+++ b/app/models/conference.py
@@ -38,6 +38,9 @@ class Conference(BaseModel):
     class Meta:
         db_table = 'conference'
         unique_together = (('conference_id', 'app'),)
+        indexes = [
+            models.Index(fields=['app', '-created_at'], name='idx_conf_app_created'),
+        ]
 
     cache_keys = (
         sorted(('id',)),

--- a/app/models/generic_event.py
+++ b/app/models/generic_event.py
@@ -32,6 +32,11 @@ class GenericEvent(BaseModel):
         data: the data of the event
     """
 
+    class Meta:
+        indexes = [
+            models.Index(fields=['app', '-created_at'], name='idx_genevent_app_created'),
+        ]
+
     id = models.UUIDField(primary_key=True, default=uuid.uuid4)
     conference = models.ForeignKey('Conference', on_delete=models.CASCADE, null=False, related_name='events')
     participant = models.ForeignKey('Participant', on_delete=models.CASCADE, null=False, related_name='events')

--- a/app/models/issue.py
+++ b/app/models/issue.py
@@ -86,6 +86,11 @@ class Issue(BaseModel):
     """
     TYPES_OF_ISSUES = TYPES_OF_ISSUES
 
+    class Meta:
+        indexes = [
+            models.Index(fields=['conference', 'type'], name='idx_issue_conf_type'),
+        ]
+
     cache_keys = (
         sorted(('id',)),
     )

--- a/app/urls.py
+++ b/app/urls.py
@@ -5,6 +5,7 @@ from .views.apps_reset_api_key_view import AppsResetApiKeyView
 from .views.apps_view import AppsView
 from .views.browser_event_view import BrowserEventView
 from .views.conference_view import ConferencesView
+from .views.conference_summary_view import ConferenceSummaryView
 from .views.connection_event_view import ConnectionEventView
 from .views.connection_view import ConnectionView
 from .views.issue_view import IssueView
@@ -55,6 +56,7 @@ urlpatterns = [
     path('apps/<uuid:pk>/reset-key', AppsResetApiKeyView.as_view(), name='app-reset-key'),
 
     path('conferences', ConferencesView.as_view(), name='conferences'),
+    path('conferences/summary', ConferenceSummaryView.as_view(), name='conferences-summary'),
     path('conferences/<uuid:pk>', ConferencesView.as_view(), name='conference'),
     path('conferences/<uuid:pk>/events', ConferenceEventsView.as_view(), name='conference-events'),
     path('conferences/<uuid:pk>/graphs', ConferenceGraphView.as_view(), name='conference-graphs'),

--- a/app/views/conference_summary_view.py
+++ b/app/views/conference_summary_view.py
@@ -1,0 +1,95 @@
+import datetime
+from collections import defaultdict
+
+from django.core.exceptions import ValidationError
+from django.db.models import Case, CharField, Count, Exists, OuterRef, Value, When
+from django.db.models.functions import TruncDate
+
+from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..utils import JSONHttpResponse
+from ..models.conference import Conference
+from ..models.issue import Issue
+from .generic_view import GenericView
+
+
+def _parse_iso(value):
+    # Python 3.8 fromisoformat doesn't accept the Z suffix that JS toISOString produces.
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    return datetime.datetime.fromisoformat(value)
+
+
+class ConferenceSummaryView(GenericView):
+    """
+    Returns conference counts grouped by day, with each day's conferences
+    bucketed into success/warning/error/ongoing. Replaces the pattern of
+    downloading all conferences to the browser and aggregating client-side.
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {'app_id': app_id, 'is_active': True}
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        try:
+            rows = (Conference.objects
+                .filter(**filters)
+                .annotate(
+                    day=TruncDate('created_at'),
+                    has_error=Exists(
+                        Issue.objects.filter(conference=OuterRef('pk'), type='e', is_active=True)
+                    ),
+                    has_warning=Exists(
+                        Issue.objects.filter(conference=OuterRef('pk'), type='w', is_active=True)
+                    ),
+                )
+                .annotate(
+                    status=Case(
+                        When(ongoing=True, then=Value('ongoing')),
+                        When(has_error=True, then=Value('error')),
+                        When(has_warning=True, then=Value('warning')),
+                        default=Value('success'),
+                        output_field=CharField(),
+                    ),
+                )
+                .values('day', 'status')
+                .annotate(count=Count('id'))
+                .order_by('day'))
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        buckets = defaultdict(lambda: {'success': 0, 'warning': 0, 'error': 0, 'ongoing': 0})
+        for row in rows:
+            day_key = row['day'].isoformat() if row['day'] else None
+            buckets[day_key][row['status']] = row['count']
+
+        data = [
+            {
+                'date': day,
+                'success': counts['success'],
+                'warning': counts['warning'],
+                'error': counts['error'],
+                'ongoing': counts['ongoing'],
+                'total': counts['success'] + counts['warning'] + counts['error'] + counts['ongoing'],
+            }
+            for day, counts in sorted(buckets.items(), key=lambda x: x[0] or '')
+        ]
+
+        return JSONHttpResponse({'data': data})


### PR DESCRIPTION
Phase 0 + Phase 1 of #20 — database indexes plus the server-side aggregation endpoint for the Conferences chart.

## Problem

The dashboard graphs tab currently downloads **all raw conferences** into the browser and aggregates them with JavaScript. On production: 42,177 conferences / 21.7 MB / ~13 seconds per dashboard load, on a trajectory to exceed the 30s gunicorn timeout and start returning 504s.

## This PR

### Phase 0 — Indexes (migration 0004)

Adds the indexes required for the summary query to scale on production. Without these, aggregation queries still do full table scans on 42K+ rows.

| Index | Purpose |
|---|---|
| `conference(app, -created_at)` | Summary endpoint filter + GROUP BY |
| `issue(conference, type)` | Exists subqueries for has_error / has_warning |
| `app_genericevent(app, -created_at)` | Future event-based summaries + cleanup queries |

### Phase 1 — Summary endpoint

New `GET /v1/conferences/summary?appId=<id>&created_at_gte=<iso>&created_at_lte=<iso>` returning daily counts bucketed by status:

```json
{
  "data": [
    {"date": "2026-04-07", "success": 416, "warning": 0, "error": 0, "ongoing": 0, "total": 416},
    {"date": "2026-04-08", "success": 148, "warning": 0, "error": 1, "ongoing": 0, "total": 149}
  ]
}
```

## Measured on local test data (2,573 conferences)

| | Size | Time |
|---|---|---|
| Full list (current) | 1,139,816 bytes | ~350ms |
| **Summary** | **854 bytes** | **<200ms** |
| Size reduction | **1,335× smaller** | |

On production (42K conferences, 21.7 MB) the reduction will be much larger because the summary scales with number of days (~30 rows) regardless of conference count.

## Implementation notes

- `CASE WHEN` expression classifies each conference into one of `ongoing | error | warning | success` (mutually exclusive stacks the chart renders).
- Postgres rejects correlated `EXISTS` subqueries inside `COUNT(...) FILTER` clauses, so we annotate the classification first and group by `(day, status)` afterwards.
- Accepts both native Python ISO format and the `Z` suffix that JavaScript's `toISOString()` produces.

## Scope

- This PR: **indexes + the summary endpoint only**. The existing `/v1/conferences` list endpoint is unchanged and still used by the Conference list tab and other charts.
- Web-side migration of the Conferences chart: peermetrics/web#25.
- Remaining charts (duration, issues, participants, connections, sessions) will migrate in follow-up PRs as described in #20.

## Test plan

- [x] Migration applies cleanly; indexes appear in pg_indexes
- [x] Curl the endpoint with valid params — returns 200 with daily rows
- [x] Curl with bad ISO string — returns 400
- [x] Curl with no appId — returns 400
- [x] Handles `Z` suffix from JavaScript toISOString
- [x] Data matches client-side aggregation over the same dataset