### PR TITLE
feat: duration/participants/issues/gum summary endpoints (Phase 2 + 3 of #20)

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -6,6 +6,9 @@ from .views.apps_view import AppsView
 from .views.browser_event_view import BrowserEventView
 from .views.conference_view import ConferencesView
 from .views.conference_summary_view import ConferenceSummaryView
+from .views.conference_duration_summary_view import ConferenceDurationSummaryView
+from .views.conference_participant_count_summary_view import ConferenceParticipantCountSummaryView
+from .views.issue_summary_view import IssueSummaryView, GetUserMediaSummaryView
 from .views.connection_event_view import ConnectionEventView
 from .views.connection_view import ConnectionView
 from .views.issue_view import IssueView
@@ -39,6 +42,8 @@ urlpatterns = [
     path('connections', ConnectionView.as_view(), name='connections'),
     path('connections/<uuid:pk>', ConnectionView.as_view(), name='connection'),
     path('issues', IssueView.as_view(), name='issues'),
+    path('issues/summary', IssueSummaryView.as_view(), name='issues-summary'),
+    path('issues/gum-summary', GetUserMediaSummaryView.as_view(), name='issues-gum-summary'),
     path('issues/<uuid:pk>', IssueView.as_view(), name='issue'),
 
     path('stats', StatsView.as_view(), name='stats'),
@@ -57,6 +62,8 @@ urlpatterns = [
 
     path('conferences', ConferencesView.as_view(), name='conferences'),
     path('conferences/summary', ConferenceSummaryView.as_view(), name='conferences-summary'),
+    path('conferences/duration-summary', ConferenceDurationSummaryView.as_view(), name='conferences-duration-summary'),
+    path('conferences/participant-count-summary', ConferenceParticipantCountSummaryView.as_view(), name='conferences-participant-count-summary'),
     path('conferences/<uuid:pk>', ConferencesView.as_view(), name='conference'),
     path('conferences/<uuid:pk>/events', ConferenceEventsView.as_view(), name='conference-events'),
     path('conferences/<uuid:pk>/graphs', ConferenceGraphView.as_view(), name='conference-graphs'),

--- a/app/views/conference_duration_summary_view.py
+++ b/app/views/conference_duration_summary_view.py
@@ -1,0 +1,90 @@
+import datetime
+
+from django.core.exceptions import ValidationError
+from django.db.models import Case, Count, IntegerField, When
+
+from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..utils import JSONHttpResponse
+from ..models.conference import Conference
+from .generic_view import GenericView
+
+
+BUCKETS = [
+    {'title': '< 1 m',    'min_sec': 0,    'max_sec': 60},
+    {'title': '1 - 3 m',  'min_sec': 60,   'max_sec': 180},
+    {'title': '3 - 5 m',  'min_sec': 180,  'max_sec': 300},
+    {'title': '5 - 10 m', 'min_sec': 300,  'max_sec': 600},
+    {'title': '10 - 15 m','min_sec': 600,  'max_sec': 900},
+    {'title': '15 - 20 m','min_sec': 900,  'max_sec': 1200},
+    {'title': '20 - 25 m','min_sec': 1200, 'max_sec': 1500},
+    {'title': '25 - 30 m','min_sec': 1500, 'max_sec': 1800},
+    {'title': '30 - 40 m','min_sec': 1800, 'max_sec': 2400},
+    {'title': '40 - 50 m','min_sec': 2400, 'max_sec': 3000},
+    {'title': '50 - 60 m','min_sec': 3000, 'max_sec': 3600},
+    {'title': '> 60 m',   'min_sec': 3600, 'max_sec': None},
+]
+
+
+def _parse_iso(value):
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    return datetime.datetime.fromisoformat(value)
+
+
+class ConferenceDurationSummaryView(GenericView):
+    """Returns conference count bucketed by duration range."""
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {'app_id': app_id, 'is_active': True}
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        whens = []
+        for i, b in enumerate(BUCKETS):
+            lo, hi = b['min_sec'], b['max_sec']
+            if hi is None:
+                whens.append(When(duration__gte=lo, then=i))
+            elif lo == 0:
+                whens.append(When(duration__lt=hi, then=i))
+            else:
+                whens.append(When(duration__gte=lo, duration__lt=hi, then=i))
+
+        try:
+            rows = (Conference.objects
+                .filter(**filters)
+                .annotate(bucket=Case(*whens, output_field=IntegerField()))
+                .values('bucket')
+                .annotate(count=Count('id'))
+                .order_by('bucket'))
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        counts_by_bucket = {r['bucket']: r['count'] for r in rows if r['bucket'] is not None}
+        data = [
+            {
+                'range': b['title'],
+                'min_sec': b['min_sec'],
+                'max_sec': b['max_sec'],
+                'count': counts_by_bucket.get(i, 0),
+            }
+            for i, b in enumerate(BUCKETS)
+        ]
+
+        return JSONHttpResponse({'data': data})

--- a/app/views/conference_participant_count_summary_view.py
+++ b/app/views/conference_participant_count_summary_view.py
@@ -1,0 +1,77 @@
+import datetime
+from collections import Counter
+
+from django.core.exceptions import ValidationError
+from django.db.models import Count, IntegerField, OuterRef, Subquery
+
+from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..utils import JSONHttpResponse
+from ..models.conference import Conference
+from ..models.participant import Participant
+from .generic_view import GenericView
+
+
+def _parse_iso(value):
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    return datetime.datetime.fromisoformat(value)
+
+
+class ConferenceParticipantCountSummaryView(GenericView):
+    """
+    Returns the distribution of conferences grouped by how many participants
+    they had. Used by the Number-of-participants pie chart.
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {'app_id': app_id, 'is_active': True}
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        try:
+            per_conf = (Conference.objects
+                .filter(**filters)
+                .annotate(
+                    participants_count=Subquery(
+                        Participant.objects.filter(
+                            conferences=OuterRef('pk'),
+                            is_active=True,
+                        ).order_by().values('conferences').annotate(
+                            cnt=Count('id', distinct=True)
+                        ).values('cnt')[:1],
+                        output_field=IntegerField(),
+                    ),
+                )
+                .values_list('participants_count', flat=True))
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        distribution = Counter()
+        total = 0
+        for count in per_conf:
+            distribution[count or 0] += 1
+            total += 1
+
+        data = [
+            {'participants': n, 'conferences': c}
+            for n, c in sorted(distribution.items())
+        ]
+
+        return JSONHttpResponse({'data': data, 'total_conferences': total})

--- a/app/views/conference_view.py
+++ b/app/views/conference_view.py
@@ -30,6 +30,9 @@ class ConferencesView(GenericView):
             'created_at__gte': 'created_at_gte',
             'created_at__lt': 'created_at_lt',
             'created_at__lte': 'created_at_lte',
+            'duration__gte': 'duration_gte',
+            'duration__lt': 'duration_lt',
+            'issues__code': 'issue_code',
         }
 
         for key, rkey in allowed_filters.items():

--- a/app/views/issue_summary_view.py
+++ b/app/views/issue_summary_view.py
@@ -1,0 +1,128 @@
+import datetime
+
+from django.core.exceptions import ValidationError
+from django.db.models import Count
+
+from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..utils import JSONHttpResponse
+from ..models.issue import Issue, ISSUES
+from .generic_view import GenericView
+
+
+def _parse_iso(value):
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    return datetime.datetime.fromisoformat(value)
+
+
+class IssueSummaryView(GenericView):
+    """
+    Returns issue counts grouped by code. Used by the Most-common-issues chart.
+    Replaces downloading all issues (73 MB+ on production) to aggregate in
+    the browser.
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {
+            'conference__app_id': app_id,
+            'is_active': True,
+        }
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        try:
+            rows = (Issue.objects
+                .filter(**filters)
+                .values('code')
+                .annotate(count=Count('id'))
+                .order_by('-count'))
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        data = [
+            {
+                'code': r['code'],
+                'title': ISSUES.get(r['code'], {}).get('title', r['code']),
+                'count': r['count'],
+            }
+            for r in rows
+        ]
+
+        return JSONHttpResponse({'data': data})
+
+
+class GetUserMediaSummaryView(GenericView):
+    """
+    Returns counts of getusermedia_error issues grouped by the error's `name`
+    field inside the JSON data. Used by the GUM (getUserMedia errors) chart.
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {
+            'conference__app_id': app_id,
+            'code': 'getusermedia_error',
+            'is_active': True,
+        }
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        from collections import Counter
+        name_counter = Counter()
+        message_by_name = {}
+
+        try:
+            issues = Issue.objects.filter(**filters).values_list('data', flat=True)
+            for data in issues:
+                if not data:
+                    continue
+                name = data.get('name') or 'Unknown'
+                name_counter[name] += 1
+                if name not in message_by_name and data.get('message'):
+                    message_by_name[name] = data['message']
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        data = [
+            {
+                'name': name,
+                'message': message_by_name.get(name, ''),
+                'count': count,
+            }
+            for name, count in name_counter.most_common()
+        ]
+
+        return JSONHttpResponse({'data': data, 'total': sum(name_counter.values())})


### PR DESCRIPTION
## Summary
- Three new aggregation endpoints so the dashboard stops downloading full /conferences and /issues payloads:
  - \`GET /v1/conferences/duration-summary\` — conference duration buckets (< 1 m through > 60 m)
  - \`GET /v1/conferences/participant-count-summary\` — participant-count distribution (0, 2, 3, …)
  - \`GET /v1/issues/summary\` — most-common-issues counts, grouped by code
  - \`GET /v1/issues/gum-summary\` — getUserMedia-error breakdown by error name
- All endpoints accept the same \`appId\` / \`created_at_gte\` / \`created_at_lte\` filter shape already used by \`/conferences/summary\`.

Depends on [#24](https://github.com/peermetrics/api/pull/24) (already merged). Phase 4 + 5 will be a follow-up PR stacked on top of this one.

## Test plan
- [ ] Smoke each endpoint against a populated app and confirm the totals match the corresponding full-table COUNTs
- [ ] Confirm \`created_at_gte\` / \`created_at_lte\` narrow results correctly
- [ ] Confirm each endpoint returns \`{"data": [...]}\` (the dashboard client unwraps \`data\` automatically)

🤖 Generated with [Claude Code](https://claude.com/claude-code)