### PR TITLE
feat: connections + sessions summary endpoints (Phase 4 + 5 of #20)

### DIFF
--- a/app/urls.py
+++ b/app/urls.py
@@ -9,6 +9,8 @@ from .views.conference_summary_view import ConferenceSummaryView
 from .views.conference_duration_summary_view import ConferenceDurationSummaryView
 from .views.conference_participant_count_summary_view import ConferenceParticipantCountSummaryView
 from .views.issue_summary_view import IssueSummaryView, GetUserMediaSummaryView
+from .views.connection_summary_view import ConnectionSummaryView, ConnectionSetupTimeSummaryView
+from .views.session_summary_view import SessionSummaryView
 from .views.connection_event_view import ConnectionEventView
 from .views.connection_view import ConnectionView
 from .views.issue_view import IssueView
@@ -40,6 +42,8 @@ urlpatterns = [
     path('connection/batch', ConnectionEventBatchView.as_view(), name='connection-batch'),
 
     path('connections', ConnectionView.as_view(), name='connections'),
+    path('connections/summary', ConnectionSummaryView.as_view(), name='connections-summary'),
+    path('connections/setup-time-summary', ConnectionSetupTimeSummaryView.as_view(), name='connections-setup-time-summary'),
     path('connections/<uuid:pk>', ConnectionView.as_view(), name='connection'),
     path('issues', IssueView.as_view(), name='issues'),
     path('issues/summary', IssueSummaryView.as_view(), name='issues-summary'),
@@ -50,6 +54,7 @@ urlpatterns = [
     path('tracks', TracksView.as_view(), name='tracks'),
 
     path('sessions', SessionView.as_view(), name='sessions'),
+    path('sessions/summary', SessionSummaryView.as_view(), name='sessions-summary'),
     path('sessions/<uuid:pk>', SessionView.as_view(), name='session'),
 
     path('organizations', OrganizatonsView.as_view(), name='organizations'),

--- a/app/urls.py
+++ b/app/urls.py
@@ -6,6 +6,9 @@ from .views.apps_view import AppsView
 from .views.browser_event_view import BrowserEventView
 from .views.conference_view import ConferencesView
 from .views.conference_summary_view import ConferenceSummaryView
+from .views.conference_duration_summary_view import ConferenceDurationSummaryView
+from .views.conference_participant_count_summary_view import ConferenceParticipantCountSummaryView
+from .views.issue_summary_view import IssueSummaryView, GetUserMediaSummaryView
 from .views.connection_event_view import ConnectionEventView
 from .views.connection_view import ConnectionView
 from .views.issue_view import IssueView
@@ -39,6 +42,8 @@ urlpatterns = [
     path('connections', ConnectionView.as_view(), name='connections'),
     path('connections/<uuid:pk>', ConnectionView.as_view(), name='connection'),
     path('issues', IssueView.as_view(), name='issues'),
+    path('issues/summary', IssueSummaryView.as_view(), name='issues-summary'),
+    path('issues/gum-summary', GetUserMediaSummaryView.as_view(), name='issues-gum-summary'),
     path('issues/<uuid:pk>', IssueView.as_view(), name='issue'),
 
     path('stats', StatsView.as_view(), name='stats'),
@@ -57,6 +62,8 @@ urlpatterns = [
 
     path('conferences', ConferencesView.as_view(), name='conferences'),
     path('conferences/summary', ConferenceSummaryView.as_view(), name='conferences-summary'),
+    path('conferences/duration-summary', ConferenceDurationSummaryView.as_view(), name='conferences-duration-summary'),
+    path('conferences/participant-count-summary', ConferenceParticipantCountSummaryView.as_view(), name='conferences-participant-count-summary'),
     path('conferences/<uuid:pk>', ConferencesView.as_view(), name='conference'),
     path('conferences/<uuid:pk>/events', ConferenceEventsView.as_view(), name='conference-events'),
     path('conferences/<uuid:pk>/graphs', ConferenceGraphView.as_view(), name='conference-graphs'),

--- a/app/views/conference_duration_summary_view.py
+++ b/app/views/conference_duration_summary_view.py
@@ -1,0 +1,90 @@
+import datetime
+
+from django.core.exceptions import ValidationError
+from django.db.models import Case, Count, IntegerField, When
+
+from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..utils import JSONHttpResponse
+from ..models.conference import Conference
+from .generic_view import GenericView
+
+
+BUCKETS = [
+    {'title': '< 1 m',    'min_sec': 0,    'max_sec': 60},
+    {'title': '1 - 3 m',  'min_sec': 60,   'max_sec': 180},
+    {'title': '3 - 5 m',  'min_sec': 180,  'max_sec': 300},
+    {'title': '5 - 10 m', 'min_sec': 300,  'max_sec': 600},
+    {'title': '10 - 15 m','min_sec': 600,  'max_sec': 900},
+    {'title': '15 - 20 m','min_sec': 900,  'max_sec': 1200},
+    {'title': '20 - 25 m','min_sec': 1200, 'max_sec': 1500},
+    {'title': '25 - 30 m','min_sec': 1500, 'max_sec': 1800},
+    {'title': '30 - 40 m','min_sec': 1800, 'max_sec': 2400},
+    {'title': '40 - 50 m','min_sec': 2400, 'max_sec': 3000},
+    {'title': '50 - 60 m','min_sec': 3000, 'max_sec': 3600},
+    {'title': '> 60 m',   'min_sec': 3600, 'max_sec': None},
+]
+
+
+def _parse_iso(value):
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    return datetime.datetime.fromisoformat(value)
+
+
+class ConferenceDurationSummaryView(GenericView):
+    """Returns conference count bucketed by duration range."""
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {'app_id': app_id, 'is_active': True}
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        whens = []
+        for i, b in enumerate(BUCKETS):
+            lo, hi = b['min_sec'], b['max_sec']
+            if hi is None:
+                whens.append(When(duration__gte=lo, then=i))
+            elif lo == 0:
+                whens.append(When(duration__lt=hi, then=i))
+            else:
+                whens.append(When(duration__gte=lo, duration__lt=hi, then=i))
+
+        try:
+            rows = (Conference.objects
+                .filter(**filters)
+                .annotate(bucket=Case(*whens, output_field=IntegerField()))
+                .values('bucket')
+                .annotate(count=Count('id'))
+                .order_by('bucket'))
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        counts_by_bucket = {r['bucket']: r['count'] for r in rows if r['bucket'] is not None}
+        data = [
+            {
+                'range': b['title'],
+                'min_sec': b['min_sec'],
+                'max_sec': b['max_sec'],
+                'count': counts_by_bucket.get(i, 0),
+            }
+            for i, b in enumerate(BUCKETS)
+        ]
+
+        return JSONHttpResponse({'data': data})

--- a/app/views/conference_participant_count_summary_view.py
+++ b/app/views/conference_participant_count_summary_view.py
@@ -1,0 +1,77 @@
+import datetime
+from collections import Counter
+
+from django.core.exceptions import ValidationError
+from django.db.models import Count, IntegerField, OuterRef, Subquery
+
+from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..utils import JSONHttpResponse
+from ..models.conference import Conference
+from ..models.participant import Participant
+from .generic_view import GenericView
+
+
+def _parse_iso(value):
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    return datetime.datetime.fromisoformat(value)
+
+
+class ConferenceParticipantCountSummaryView(GenericView):
+    """
+    Returns the distribution of conferences grouped by how many participants
+    they had. Used by the Number-of-participants pie chart.
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {'app_id': app_id, 'is_active': True}
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        try:
+            per_conf = (Conference.objects
+                .filter(**filters)
+                .annotate(
+                    participants_count=Subquery(
+                        Participant.objects.filter(
+                            conferences=OuterRef('pk'),
+                            is_active=True,
+                        ).order_by().values('conferences').annotate(
+                            cnt=Count('id', distinct=True)
+                        ).values('cnt')[:1],
+                        output_field=IntegerField(),
+                    ),
+                )
+                .values_list('participants_count', flat=True))
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        distribution = Counter()
+        total = 0
+        for count in per_conf:
+            distribution[count or 0] += 1
+            total += 1
+
+        data = [
+            {'participants': n, 'conferences': c}
+            for n, c in sorted(distribution.items())
+        ]
+
+        return JSONHttpResponse({'data': data, 'total_conferences': total})

--- a/app/views/conference_view.py
+++ b/app/views/conference_view.py
@@ -39,6 +39,12 @@ class ConferencesView(GenericView):
             if request.GET.get(rkey):
                 filters[key] = request.GET.get(rkey)
 
+        ids_param = request.GET.get('conference_ids')
+        if ids_param:
+            ids = [i for i in ids_param.split(',') if i]
+            if ids:
+                filters['id__in'] = ids
+
         if not filters:
             raise PMError(status=400, app_error=MISSING_PARAMETERS)
 

--- a/app/views/conference_view.py
+++ b/app/views/conference_view.py
@@ -30,6 +30,9 @@ class ConferencesView(GenericView):
             'created_at__gte': 'created_at_gte',
             'created_at__lt': 'created_at_lt',
             'created_at__lte': 'created_at_lte',
+            'duration__gte': 'duration_gte',
+            'duration__lt': 'duration_lt',
+            'issues__code': 'issue_code',
         }
 
         for key, rkey in allowed_filters.items():

--- a/app/views/connection_summary_view.py
+++ b/app/views/connection_summary_view.py
@@ -1,0 +1,187 @@
+import datetime
+from collections import Counter
+
+from django.core.exceptions import ValidationError
+from django.db.models import Case, Count, IntegerField, When
+
+from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..utils import JSONHttpResponse
+from ..models.connection import Connection, TYPE_OF_CONNECTIONS_ENUM
+from .generic_view import GenericView
+
+
+SETUP_TIME_BUCKETS = [
+    {'title': '< 250 ms',       'min_ms': 0,    'max_ms': 250},
+    {'title': '250 - 500 ms',   'min_ms': 250,  'max_ms': 500},
+    {'title': '500 - 750 ms',   'min_ms': 500,  'max_ms': 750},
+    {'title': '750 - 1000 ms',  'min_ms': 750,  'max_ms': 1000},
+    {'title': '1000 - 1500 ms', 'min_ms': 1000, 'max_ms': 1500},
+    {'title': '1500 - 2000 ms', 'min_ms': 1500, 'max_ms': 2000},
+    {'title': '2000 - 2500 ms', 'min_ms': 2000, 'max_ms': 2500},
+    {'title': '2500 - 3000 ms', 'min_ms': 2500, 'max_ms': 3000},
+    {'title': '3000 - 4000 ms', 'min_ms': 3000, 'max_ms': 4000},
+    {'title': '4000 - 5000 ms', 'min_ms': 4000, 'max_ms': 5000},
+    {'title': '> 5000 ms',      'min_ms': 5000, 'max_ms': None},
+]
+
+
+def _parse_iso(value):
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    return datetime.datetime.fromisoformat(value)
+
+
+def _parse_time(value):
+    if not value:
+        return None
+    try:
+        return _parse_iso(value) if isinstance(value, str) else value
+    except Exception:
+        return None
+
+
+def _bucket_for(ms):
+    for i, b in enumerate(SETUP_TIME_BUCKETS):
+        if b['max_ms'] is None:
+            if ms >= b['min_ms']:
+                return i
+        elif b['min_ms'] <= ms < b['max_ms']:
+            return i
+    return None
+
+
+class ConnectionSummaryView(GenericView):
+    """
+    Returns connection counts grouped by type — relay (TURN) vs direct.
+    Replaces the Relayed-connections pie chart's client-side aggregation.
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {
+            'conference__app_id': app_id,
+            'is_active': True,
+        }
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        relay_code = TYPE_OF_CONNECTIONS_ENUM['relay']
+
+        try:
+            rows = (Connection.objects
+                .filter(**filters)
+                .exclude(type__isnull=True)
+                .annotate(
+                    group=Case(
+                        When(type=relay_code, then=1),
+                        default=0,
+                        output_field=IntegerField(),
+                    ),
+                )
+                .values('group')
+                .annotate(count=Count('id')))
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        counts = {0: 0, 1: 0}
+        for row in rows:
+            counts[row['group']] = row['count']
+
+        return JSONHttpResponse({
+            'data': [
+                {'name': 'Direct', 'count': counts[0]},
+                {'name': 'Relayed', 'count': counts[1]},
+            ],
+        })
+
+
+class ConnectionSetupTimeSummaryView(GenericView):
+    """
+    Returns counts of connections bucketed by initial-negotiation setup
+    time (end_time - start_time on the first 'connected' negotiation
+    in connection_info.negotiations).
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {
+            'conference__app_id': app_id,
+            'is_active': True,
+        }
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        counters = Counter()
+        conferences_per_bucket = {i: set() for i in range(len(SETUP_TIME_BUCKETS))}
+
+        try:
+            rows = Connection.objects.filter(**filters).values_list(
+                'connection_info', 'conference_id'
+            )
+            for info, conf_id in rows:
+                if not info:
+                    continue
+                negotiations = info.get('negotiations') or []
+                if not negotiations:
+                    continue
+                first = negotiations[0]
+                if first.get('status') != 'connected':
+                    continue
+                start = _parse_time(first.get('start_time'))
+                end = _parse_time(first.get('end_time'))
+                if not start or not end:
+                    continue
+                ms = (end - start).total_seconds() * 1000
+                if ms < 0:
+                    continue
+                idx = _bucket_for(ms)
+                if idx is None:
+                    continue
+                counters[idx] += 1
+                conferences_per_bucket[idx].add(str(conf_id))
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        data = []
+        for i, b in enumerate(SETUP_TIME_BUCKETS):
+            data.append({
+                'range': b['title'],
+                'min_ms': b['min_ms'],
+                'max_ms': b['max_ms'],
+                'count': counters.get(i, 0),
+                'conference_ids': list(conferences_per_bucket[i]),
+            })
+
+        return JSONHttpResponse({'data': data})

--- a/app/views/issue_summary_view.py
+++ b/app/views/issue_summary_view.py
@@ -1,0 +1,128 @@
+import datetime
+
+from django.core.exceptions import ValidationError
+from django.db.models import Count
+
+from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..utils import JSONHttpResponse
+from ..models.issue import Issue, ISSUES
+from .generic_view import GenericView
+
+
+def _parse_iso(value):
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    return datetime.datetime.fromisoformat(value)
+
+
+class IssueSummaryView(GenericView):
+    """
+    Returns issue counts grouped by code. Used by the Most-common-issues chart.
+    Replaces downloading all issues (73 MB+ on production) to aggregate in
+    the browser.
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {
+            'conference__app_id': app_id,
+            'is_active': True,
+        }
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        try:
+            rows = (Issue.objects
+                .filter(**filters)
+                .values('code')
+                .annotate(count=Count('id'))
+                .order_by('-count'))
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        data = [
+            {
+                'code': r['code'],
+                'title': ISSUES.get(r['code'], {}).get('title', r['code']),
+                'count': r['count'],
+            }
+            for r in rows
+        ]
+
+        return JSONHttpResponse({'data': data})
+
+
+class GetUserMediaSummaryView(GenericView):
+    """
+    Returns counts of getusermedia_error issues grouped by the error's `name`
+    field inside the JSON data. Used by the GUM (getUserMedia errors) chart.
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {
+            'conference__app_id': app_id,
+            'code': 'getusermedia_error',
+            'is_active': True,
+        }
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        from collections import Counter
+        name_counter = Counter()
+        message_by_name = {}
+
+        try:
+            issues = Issue.objects.filter(**filters).values_list('data', flat=True)
+            for data in issues:
+                if not data:
+                    continue
+                name = data.get('name') or 'Unknown'
+                name_counter[name] += 1
+                if name not in message_by_name and data.get('message'):
+                    message_by_name[name] = data['message']
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        data = [
+            {
+                'name': name,
+                'message': message_by_name.get(name, ''),
+                'count': count,
+            }
+            for name, count in name_counter.most_common()
+        ]
+
+        return JSONHttpResponse({'data': data, 'total': sum(name_counter.values())})

--- a/app/views/session_summary_view.py
+++ b/app/views/session_summary_view.py
@@ -1,0 +1,107 @@
+import datetime
+from collections import Counter, defaultdict
+
+from django.core.exceptions import ValidationError
+
+from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..utils import JSONHttpResponse
+from ..models.session import Session
+from .generic_view import GenericView
+
+
+def _parse_iso(value):
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    return datetime.datetime.fromisoformat(value)
+
+
+class SessionSummaryView(GenericView):
+    """
+    Returns session counts aggregated by browser, OS, and country.
+    Replaces downloading all sessions to aggregate client-side in the
+    Browsers, Operating Systems, and Map charts.
+
+    Also returns geo points (lat/lon) for rendering on the map chart.
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {
+            'conference__app_id': app_id,
+            'is_active': True,
+        }
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        browsers = Counter()
+        oses = Counter()
+        countries = Counter()
+        cities = {}  # city name -> {lat, lon, count}
+
+        try:
+            rows = Session.objects.filter(**filters).values_list('platform', 'geo_ip')
+            for platform, geo_ip in rows:
+                if platform:
+                    browser = (platform.get('browser') or {}).get('name') or 'Unknown'
+                    os_name = (platform.get('os') or {}).get('name') or 'Unknown'
+                    browsers[browser] += 1
+                    oses[os_name] += 1
+
+                if geo_ip:
+                    country_code = geo_ip.get('country_code')
+                    if country_code:
+                        countries[country_code] += 1
+
+                    city = geo_ip.get('city')
+                    lat = geo_ip.get('latitude')
+                    lon = geo_ip.get('longitude')
+                    if city and lat is not None and lon is not None:
+                        try:
+                            lat_f = float(lat)
+                            lon_f = float(lon)
+                            if lat_f or lon_f:
+                                if city in cities:
+                                    cities[city]['count'] += 1
+                                else:
+                                    cities[city] = {
+                                        'city': city,
+                                        'latitude': lat_f,
+                                        'longitude': lon_f,
+                                        'count': 1,
+                                    }
+                        except (TypeError, ValueError):
+                            pass
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        return JSONHttpResponse({
+            'browsers': [
+                {'name': k, 'count': v}
+                for k, v in browsers.most_common()
+            ],
+            'os': [
+                {'name': k, 'count': v}
+                for k, v in oses.most_common()
+            ],
+            'countries': [
+                {'code': k, 'count': v}
+                for k, v in countries.most_common()
+            ],
+            'cities': list(cities.values()),
+        })


### PR DESCRIPTION
## Summary
**Stacked on top of #26** — this PR will show both Phase 2+3 and Phase 4+5 commits until #26 merges, at which point it will rebase down to just the Phase 4+5 commit. Reviewers can focus on \`7cd2ec4\`.

Adds the final three aggregation endpoints so the dashboard charts are fully server-side:

- \`GET /v1/connections/summary\` — relay vs direct connection counts (powers Relayed-connections pie chart)
- \`GET /v1/connections/setup-time-summary\` — connection setup-time buckets (< 250 ms → > 5000 ms), each bucket includes \`conference_ids\` so the click-to-detail modal can page through matching conferences without re-running the aggregation
- \`GET /v1/sessions/summary\` — browsers / OS / country / city (lat-lon-count) aggregates (powers Browsers, Operating systems, and Map charts)

Also extends \`/conferences\` with \`?conference_ids=a,b,c\` so the setup-time chart can fetch matching conferences on click via \`id__in\`.

With this merged, every chart on the graphs tab reads a server-side aggregate. No more full-table downloads to the browser.

## Test plan
- [ ] Smoke each endpoint and confirm totals match equivalent raw-table aggregation
- [ ] Click a setup-time bucket in the UI and confirm matched conferences open in the modal
- [ ] Confirm \`conference_ids=\` filter on \`/conferences\` returns exactly the requested rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)