### PR TITLE
feat: Redis cache + pre-warm for dashboard summary endpoints (Phase C of #20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -987,6 +987,8 @@ Private endpoints are used by the web interface to query data. They require user
   - `GET`, query parameters:
     - `appId`: Filter by app
     - `participantId`: Filter by participant
+    - `issue_code`: Filter conferences that contain at least one active issue with this code
+      - Returns each conference once even if multiple matching issues exist
 
 - `/conferences/<uuid:pk>`: Get a specific conference
   - `GET`

--- a/app/management/commands/prewarm_summaries.py
+++ b/app/management/commands/prewarm_summaries.py
@@ -1,0 +1,98 @@
+"""
+Pre-warm the dashboard-summary Redis cache so first visitors don't pay
+the cold-query tax. Intended to run every ~30s via ECS scheduled task.
+
+For each active app that has seen recent data, walks every summary view
+with the same (appId, created_at_gte) filter the dashboard sends by
+default (last 30 days). The views themselves populate the cache on miss.
+"""
+import datetime
+import logging
+import time
+
+from django.core.management.base import BaseCommand
+from django.test.client import RequestFactory
+
+from app.models.app import App
+from app.models.conference import Conference
+
+from app.views.conference_summary_view import ConferenceSummaryView
+from app.views.conference_duration_summary_view import ConferenceDurationSummaryView
+from app.views.conference_participant_count_summary_view import ConferenceParticipantCountSummaryView
+from app.views.issue_summary_view import IssueSummaryView, GetUserMediaSummaryView
+from app.views.connection_summary_view import ConnectionSummaryView, ConnectionSetupTimeSummaryView
+from app.views.session_summary_view import SessionSummaryView
+
+logger = logging.getLogger(__name__)
+
+# (label, view)
+VIEWS = [
+    ('conferences.summary',                  ConferenceSummaryView),
+    ('conferences.duration_summary',         ConferenceDurationSummaryView),
+    ('conferences.participant_count_summary', ConferenceParticipantCountSummaryView),
+    ('issues.summary',                       IssueSummaryView),
+    ('issues.gum_summary',                   GetUserMediaSummaryView),
+    ('connections.summary',                  ConnectionSummaryView),
+    ('connections.setup_time_summary',       ConnectionSetupTimeSummaryView),
+    ('sessions.summary',                     SessionSummaryView),
+]
+
+
+class Command(BaseCommand):
+    help = 'Pre-compute dashboard summary responses and cache them'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--days',
+            type=int,
+            default=30,
+            help='Window to warm (default: 30 days, matches dashboard default)',
+        )
+        parser.add_argument(
+            '--active-within-days',
+            type=int,
+            default=2,
+            help='Only warm apps that saw a conference in the last N days (default: 2)',
+        )
+
+    def handle(self, *args, **options):
+        window_days = options['days']
+        active_within = options['active_within_days']
+
+        since_window = datetime.datetime.utcnow() - datetime.timedelta(days=window_days)
+        active_since = datetime.datetime.utcnow() - datetime.timedelta(days=active_within)
+
+        # Apps with any conference in the recent window — skip tenants with
+        # no traffic so warming doesn't scan their cold tables.
+        recent_app_ids = (Conference.objects
+            .filter(created_at__gte=active_since)
+            .values_list('app_id', flat=True)
+            .distinct())
+        apps = App.objects.filter(id__in=list(recent_app_ids), is_active=True)
+        count = apps.count()
+        self.stdout.write(f'Warming {count} active apps ({window_days}d window)')
+
+        rf = RequestFactory()
+        created_at_gte = since_window.isoformat() + 'Z'
+        warmed = 0
+        failed = 0
+
+        for app in apps:
+            for label, view_cls in VIEWS:
+                req = rf.get('/v1/' + label, {
+                    'appId': str(app.id),
+                    'created_at_gte': created_at_gte,
+                })
+                started = time.monotonic()
+                try:
+                    view_cls.get(req)
+                    warmed += 1
+                except Exception as e:
+                    failed += 1
+                    logger.warning('prewarm %s for app %s failed: %s', label, app.id, e)
+                elapsed_ms = (time.monotonic() - started) * 1000
+                if elapsed_ms > 500:
+                    self.stdout.write(f'  slow: {label} app={app.id} {elapsed_ms:.0f}ms')
+
+        self.stdout.write(f'Warmed {warmed} summary entries across {count} apps' +
+                          (f' ({failed} failed)' if failed else ''))

--- a/app/summary_cache.py
+++ b/app/summary_cache.py
@@ -33,12 +33,30 @@ CACHE_KEY_PARAMS = (
     'participantId',
 )
 
+# Params whose ISO timestamps should be truncated to the minute before hashing,
+# so that the dashboard's millisecond-precise `now - 30d` doesn't produce a
+# unique cache key per page load. Bucketing means two requests in the same
+# wall-clock minute share an entry; correctness still holds because the cache
+# entry's own TTL bounds staleness regardless of bucket size.
+BUCKETED_PARAMS = ('created_at_gte', 'created_at_lte')
+
+
+def _bucket_minute(value):
+    # ISO 8601: 2026-03-28T17:13:18.382Z -> 2026-03-28T17:13Z (first 16 chars
+    # are YYYY-MM-DDTHH:MM). Anything that doesn't match the layout is
+    # passed through unchanged so the key still differentiates malformed input.
+    if not value or len(value) < 16 or value[10] != 'T' or value[13] != ':':
+        return value
+    return value[:16] + 'Z'
+
 
 def _make_key(endpoint, request):
     parts = [endpoint]
     for name in CACHE_KEY_PARAMS:
         val = request.GET.get(name)
         if val:
+            if name in BUCKETED_PARAMS:
+                val = _bucket_minute(val)
             parts.append(f'{name}={val}')
     raw = '|'.join(parts)
     # Keep key short but unique; include a readable prefix for ops visibility.

--- a/app/summary_cache.py
+++ b/app/summary_cache.py
@@ -1,0 +1,75 @@
+"""
+Short-TTL Redis cache for dashboard summary endpoints.
+
+The summary endpoints run SQL aggregations that are fast enough on their own
+but get called by every dashboard page load. Cache the computed JSON for
+~60 seconds so concurrent viewers share the same roll-up.
+
+Keys are derived from the endpoint name + all request filters, so different
+date ranges / apps get independent entries. TTL-only — no explicit
+invalidation — because the data is strictly additive (new conferences,
+sessions, issues arrive over time) and a sub-minute staleness window is
+acceptable for a dashboard.
+"""
+import hashlib
+import json
+import logging
+
+from django.conf import settings
+from django.core.cache import cache
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_TTL_SECONDS = 60
+KEY_PREFIX = 'summary'
+
+# The query-string params that factor into the cache key for each endpoint.
+# Anything not listed here is ignored (e.g. trailing slashes, user agent, etc).
+CACHE_KEY_PARAMS = (
+    'appId',
+    'created_at_gte',
+    'created_at_lte',
+    'conferenceId',
+    'participantId',
+)
+
+
+def _make_key(endpoint, request):
+    parts = [endpoint]
+    for name in CACHE_KEY_PARAMS:
+        val = request.GET.get(name)
+        if val:
+            parts.append(f'{name}={val}')
+    raw = '|'.join(parts)
+    # Keep key short but unique; include a readable prefix for ops visibility.
+    digest = hashlib.sha1(raw.encode()).hexdigest()[:16]
+    return f'{KEY_PREFIX}:{endpoint}:{digest}'
+
+
+def get_ttl():
+    return getattr(settings, 'SUMMARY_CACHE_TTL', DEFAULT_TTL_SECONDS)
+
+
+def cached_json(endpoint, request, compute):
+    """
+    Returns (payload_dict, was_cached_bool).
+
+    `compute` is called only on cache miss and must return the JSON-serializable
+    dict the endpoint would have returned.
+    """
+    key = _make_key(endpoint, request)
+    try:
+        cached = cache.get(key)
+    except Exception as e:
+        logger.warning('summary cache get failed for %s: %s', key, e)
+        cached = None
+
+    if cached is not None:
+        return cached, True
+
+    payload = compute()
+    try:
+        cache.set(key, payload, timeout=get_ttl())
+    except Exception as e:
+        logger.warning('summary cache set failed for %s: %s', key, e)
+    return payload, False

--- a/app/tests/test_pr26_regressions.py
+++ b/app/tests/test_pr26_regressions.py
@@ -1,0 +1,143 @@
+import json
+
+from django.test import Client, TestCase
+
+from app.models.app import App
+from app.models.conference import Conference
+from app.models.issue import Issue
+from app.models.organization import Organization
+from app.models.participant import Participant
+from app.models.session import Session
+
+
+class PR26RegressionTests(TestCase):
+    def setUp(self):
+        self.client = Client()
+        self.organization = Organization.objects.create(name="Test Org")
+        self.app = App.objects.create(
+            name="Test App",
+            api_key="a" * 32,
+            organization=self.organization,
+        )
+
+    def _make_conference_graph(self, conference_id):
+        conference = Conference.objects.create(
+            conference_id=conference_id,
+            app=self.app,
+        )
+        participant = Participant.objects.create(
+            participant_id=f"{conference_id}-participant",
+            app=self.app,
+        )
+        participant.conferences.add(conference)
+        session = Session.objects.create(
+            conference=conference,
+            participant=participant,
+        )
+        return conference, participant, session
+
+    def test_conferences_issue_code_filter_returns_distinct_conferences(self):
+        conference, participant, session = self._make_conference_graph("conf-1")
+
+        Issue.objects.create(
+            session=session,
+            conference=conference,
+            participant=participant,
+            type=Issue.TYPES_OF_ISSUES["warning"],
+            code="getusermedia_error",
+            data={"name": "NotFoundError"},
+        )
+        Issue.objects.create(
+            session=session,
+            conference=conference,
+            participant=participant,
+            type=Issue.TYPES_OF_ISSUES["warning"],
+            code="getusermedia_error",
+            data={"name": "NotFoundError"},
+        )
+
+        response = self.client.get(
+            "/v1/conferences",
+            {
+                "appId": str(self.app.id),
+                "issue_code": "getusermedia_error",
+                "limit": "50",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.content)
+        self.assertEqual(payload["count"], 1)
+        self.assertEqual(len(payload["results"]), 1)
+        self.assertEqual(payload["results"][0]["id"], str(conference.id))
+
+    def test_conferences_issue_code_filter_ignores_inactive_issues(self):
+        conference_active, participant_active, session_active = self._make_conference_graph("conf-active")
+        conference_inactive, participant_inactive, session_inactive = self._make_conference_graph("conf-inactive")
+
+        Issue.objects.create(
+            session=session_active,
+            conference=conference_active,
+            participant=participant_active,
+            type=Issue.TYPES_OF_ISSUES["warning"],
+            code="getusermedia_error",
+            data={"name": "NotFoundError"},
+            is_active=True,
+        )
+        Issue.objects.create(
+            session=session_inactive,
+            conference=conference_inactive,
+            participant=participant_inactive,
+            type=Issue.TYPES_OF_ISSUES["warning"],
+            code="getusermedia_error",
+            data={"name": "NotReadableError"},
+            is_active=False,
+        )
+
+        response = self.client.get(
+            "/v1/conferences",
+            {
+                "appId": str(self.app.id),
+                "issue_code": "getusermedia_error",
+                "limit": "50",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.content)
+        returned_ids = {row["id"] for row in payload["results"]}
+        self.assertEqual(returned_ids, {str(conference_active.id)})
+        self.assertEqual(payload["count"], 1)
+
+    def test_gum_summary_skips_non_dict_issue_data(self):
+        conference, participant, session = self._make_conference_graph("conf-gum")
+
+        Issue.objects.create(
+            session=session,
+            conference=conference,
+            participant=participant,
+            type=Issue.TYPES_OF_ISSUES["warning"],
+            code="getusermedia_error",
+            data={"name": "NotAllowedError", "message": "Permission denied"},
+        )
+        Issue.objects.create(
+            session=session,
+            conference=conference,
+            participant=participant,
+            type=Issue.TYPES_OF_ISSUES["warning"],
+            code="getusermedia_error",
+            data="malformed",
+        )
+
+        response = self.client.get(
+            "/v1/issues/gum-summary",
+            {
+                "appId": str(self.app.id),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        payload = json.loads(response.content)
+        self.assertEqual(payload["total"], 1)
+        self.assertEqual(payload["data"][0]["name"], "NotAllowedError")
+        self.assertEqual(payload["data"][0]["count"], 1)

--- a/app/tests/test_prewarm_summaries.py
+++ b/app/tests/test_prewarm_summaries.py
@@ -1,0 +1,41 @@
+"""
+Smoke tests for prewarm_summaries management command (PR #28).
+"""
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from app.models.app import App
+from app.models.conference import Conference
+from app.models.organization import Organization
+
+
+class PrewarmSummariesSmokeTests(TestCase):
+    def test_runs_with_no_qualifying_apps(self):
+        out = StringIO()
+        err = StringIO()
+        call_command('prewarm_summaries', stdout=out, stderr=err)
+
+        combined = out.getvalue() + err.getvalue()
+        self.assertIn('Warming 0 active apps', combined)
+        self.assertIn('Warmed 0 summary entries across 0 apps', combined)
+
+    def test_runs_for_one_app_with_recent_conference(self):
+        org = Organization.objects.create(name='Prewarm Org')
+        app = App.objects.create(
+            name='Prewarm App',
+            api_key='b' * 32,
+            organization=org,
+        )
+        Conference.objects.create(
+            conference_id='prewarm-conf-1',
+            app=app,
+        )
+
+        out = StringIO()
+        call_command('prewarm_summaries', stdout=out, stderr=StringIO())
+        text = out.getvalue()
+
+        self.assertIn('Warming 1 active apps', text)
+        self.assertIn('Warmed 8 summary entries across 1 apps', text)

--- a/app/tests/test_summary_cache.py
+++ b/app/tests/test_summary_cache.py
@@ -51,6 +51,34 @@ class SummaryCacheTests(SimpleTestCase):
         )
         self.assertNotEqual(_make_key('issues.summary', a), _make_key('issues.summary', b))
 
+    def test_make_key_buckets_sub_minute_timestamp_precision(self):
+        # The dashboard sends `new Date().toISOString()` minus 30d, which is
+        # millisecond-precise. Two reloads seconds apart must collapse to the
+        # same key, otherwise prewarm cannot help and Redis fills with
+        # single-use entries.
+        rf = RequestFactory()
+        a = rf.get('/', {
+            'appId': '11111111-1111-1111-1111-111111111111',
+            'created_at_gte': '2026-03-28T17:13:18.382Z',
+        })
+        b = rf.get('/', {
+            'appId': '11111111-1111-1111-1111-111111111111',
+            'created_at_gte': '2026-03-28T17:13:42.001Z',
+        })
+        self.assertEqual(_make_key('sessions.summary', a), _make_key('sessions.summary', b))
+
+    def test_make_key_separates_distinct_minutes(self):
+        rf = RequestFactory()
+        a = rf.get('/', {
+            'appId': '11111111-1111-1111-1111-111111111111',
+            'created_at_gte': '2026-03-28T17:13:00Z',
+        })
+        b = rf.get('/', {
+            'appId': '11111111-1111-1111-1111-111111111111',
+            'created_at_gte': '2026-03-28T17:14:00Z',
+        })
+        self.assertNotEqual(_make_key('sessions.summary', a), _make_key('sessions.summary', b))
+
     def test_make_key_ignores_query_params_not_in_cache_key_params(self):
         rf = RequestFactory()
         base = rf.get('/', {'appId': '11111111-1111-1111-1111-111111111111'})

--- a/app/tests/test_summary_cache.py
+++ b/app/tests/test_summary_cache.py
@@ -1,0 +1,135 @@
+"""
+Unit tests for app.summary_cache (PR #28): LocMem backend, no Redis required.
+"""
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import RequestFactory, SimpleTestCase, override_settings
+
+from app.summary_cache import _make_key, cached_json, get_ttl
+
+
+@override_settings(
+    CACHES={
+        'default': {
+            'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+            'LOCATION': 'test-summary-cache-locmem',
+        }
+    }
+)
+class SummaryCacheTests(SimpleTestCase):
+    def setUp(self):
+        cache.clear()
+
+    def test_make_key_same_params_same_digest(self):
+        rf = RequestFactory()
+        a = rf.get('/', {'appId': '11111111-1111-1111-1111-111111111111'})
+        b = rf.get('/', {'appId': '11111111-1111-1111-1111-111111111111'})
+        self.assertEqual(_make_key('conferences.summary', a), _make_key('conferences.summary', b))
+
+    def test_make_key_different_app_different_digest(self):
+        rf = RequestFactory()
+        a = rf.get('/', {'appId': '11111111-1111-1111-1111-111111111111'})
+        b = rf.get('/', {'appId': '22222222-2222-2222-2222-222222222222'})
+        self.assertNotEqual(_make_key('conferences.summary', a), _make_key('conferences.summary', b))
+
+    def test_make_key_different_date_range_different_digest(self):
+        rf = RequestFactory()
+        a = rf.get(
+            '/',
+            {
+                'appId': '11111111-1111-1111-1111-111111111111',
+                'created_at_gte': '2026-01-01T00:00:00Z',
+            },
+        )
+        b = rf.get(
+            '/',
+            {
+                'appId': '11111111-1111-1111-1111-111111111111',
+                'created_at_gte': '2026-02-01T00:00:00Z',
+            },
+        )
+        self.assertNotEqual(_make_key('issues.summary', a), _make_key('issues.summary', b))
+
+    def test_make_key_ignores_query_params_not_in_cache_key_params(self):
+        rf = RequestFactory()
+        base = rf.get('/', {'appId': '11111111-1111-1111-1111-111111111111'})
+        with_extra = rf.get(
+            '/',
+            {
+                'appId': '11111111-1111-1111-1111-111111111111',
+                'limit': '50',
+                'offset': '10',
+                'foo': 'bar',
+            },
+        )
+        self.assertEqual(_make_key('sessions.summary', base), _make_key('sessions.summary', with_extra))
+
+    def test_make_key_different_endpoint_different_digest(self):
+        rf = RequestFactory()
+        req = rf.get('/', {'appId': '11111111-1111-1111-1111-111111111111'})
+        self.assertNotEqual(
+            _make_key('conferences.summary', req),
+            _make_key('issues.summary', req),
+        )
+
+    def test_cached_json_miss_then_hit_compute_once(self):
+        rf = RequestFactory()
+        req = rf.get('/', {'appId': '11111111-1111-1111-1111-111111111111'})
+        calls = []
+
+        def compute():
+            calls.append(1)
+            return {'data': [{'n': 1}]}
+
+        p1, hit1 = cached_json('conferences.summary', req, compute)
+        p2, hit2 = cached_json('conferences.summary', req, compute)
+
+        self.assertEqual(len(calls), 1)
+        self.assertFalse(hit1)
+        self.assertTrue(hit2)
+        self.assertEqual(p1, p2)
+        self.assertEqual(p1['data'][0]['n'], 1)
+
+    @override_settings(SUMMARY_CACHE_TTL=42)
+    def test_get_ttl_reads_setting(self):
+        self.assertEqual(get_ttl(), 42)
+
+    def test_make_key_includes_conference_id_when_present(self):
+        rf = RequestFactory()
+        a = rf.get('/', {'appId': '11111111-1111-1111-1111-111111111111'})
+        b = rf.get(
+            '/',
+            {
+                'appId': '11111111-1111-1111-1111-111111111111',
+                'conferenceId': 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+            },
+        )
+        self.assertNotEqual(_make_key('conferences.summary', a), _make_key('conferences.summary', b))
+
+    def test_cached_json_cache_get_failure_still_returns_payload(self):
+        rf = RequestFactory()
+        req = rf.get('/', {'appId': '11111111-1111-1111-1111-111111111111'})
+
+        def compute():
+            return {'ok': True}
+
+        with patch('app.summary_cache.cache.get', side_effect=RuntimeError('redis down')):
+            with patch('app.summary_cache.cache.set', return_value=True):
+                payload, hit = cached_json('issues.summary', req, compute)
+
+        self.assertFalse(hit)
+        self.assertEqual(payload, {'ok': True})
+
+    def test_cached_json_cache_set_failure_still_returns_payload(self):
+        rf = RequestFactory()
+        req = rf.get('/', {'appId': '11111111-1111-1111-1111-111111111111'})
+
+        def compute():
+            return {'stored': False}
+
+        with patch('app.summary_cache.cache.set', side_effect=RuntimeError('redis down')):
+            payload, hit = cached_json('connections.summary', req, compute)
+
+        self.assertFalse(hit)
+        self.assertEqual(payload, {'stored': False})

--- a/app/urls.py
+++ b/app/urls.py
@@ -9,6 +9,8 @@ from .views.conference_summary_view import ConferenceSummaryView
 from .views.conference_duration_summary_view import ConferenceDurationSummaryView
 from .views.conference_participant_count_summary_view import ConferenceParticipantCountSummaryView
 from .views.issue_summary_view import IssueSummaryView, GetUserMediaSummaryView
+from .views.connection_summary_view import ConnectionSummaryView, ConnectionSetupTimeSummaryView
+from .views.session_summary_view import SessionSummaryView
 from .views.connection_event_view import ConnectionEventView
 from .views.connection_view import ConnectionView
 from .views.issue_view import IssueView
@@ -40,6 +42,8 @@ urlpatterns = [
     path('connection/batch', ConnectionEventBatchView.as_view(), name='connection-batch'),
 
     path('connections', ConnectionView.as_view(), name='connections'),
+    path('connections/summary', ConnectionSummaryView.as_view(), name='connections-summary'),
+    path('connections/setup-time-summary', ConnectionSetupTimeSummaryView.as_view(), name='connections-setup-time-summary'),
     path('connections/<uuid:pk>', ConnectionView.as_view(), name='connection'),
     path('issues', IssueView.as_view(), name='issues'),
     path('issues/summary', IssueSummaryView.as_view(), name='issues-summary'),
@@ -50,6 +54,7 @@ urlpatterns = [
     path('tracks', TracksView.as_view(), name='tracks'),
 
     path('sessions', SessionView.as_view(), name='sessions'),
+    path('sessions/summary', SessionSummaryView.as_view(), name='sessions-summary'),
     path('sessions/<uuid:pk>', SessionView.as_view(), name='session'),
 
     path('organizations', OrganizatonsView.as_view(), name='organizations'),

--- a/app/urls.py
+++ b/app/urls.py
@@ -6,6 +6,9 @@ from .views.apps_view import AppsView
 from .views.browser_event_view import BrowserEventView
 from .views.conference_view import ConferencesView
 from .views.conference_summary_view import ConferenceSummaryView
+from .views.conference_duration_summary_view import ConferenceDurationSummaryView
+from .views.conference_participant_count_summary_view import ConferenceParticipantCountSummaryView
+from .views.issue_summary_view import IssueSummaryView, GetUserMediaSummaryView
 from .views.connection_event_view import ConnectionEventView
 from .views.connection_view import ConnectionView
 from .views.issue_view import IssueView
@@ -39,6 +42,8 @@ urlpatterns = [
     path('connections', ConnectionView.as_view(), name='connections'),
     path('connections/<uuid:pk>', ConnectionView.as_view(), name='connection'),
     path('issues', IssueView.as_view(), name='issues'),
+    path('issues/summary', IssueSummaryView.as_view(), name='issues-summary'),
+    path('issues/gum-summary', GetUserMediaSummaryView.as_view(), name='issues-gum-summary'),
     path('issues/<uuid:pk>', IssueView.as_view(), name='issue'),
 
     path('stats', StatsView.as_view(), name='stats'),
@@ -57,6 +62,8 @@ urlpatterns = [
 
     path('conferences', ConferencesView.as_view(), name='conferences'),
     path('conferences/summary', ConferenceSummaryView.as_view(), name='conferences-summary'),
+    path('conferences/duration-summary', ConferenceDurationSummaryView.as_view(), name='conferences-duration-summary'),
+    path('conferences/participant-count-summary', ConferenceParticipantCountSummaryView.as_view(), name='conferences-participant-count-summary'),
     path('conferences/<uuid:pk>', ConferencesView.as_view(), name='conference'),
     path('conferences/<uuid:pk>/events', ConferenceEventsView.as_view(), name='conference-events'),
     path('conferences/<uuid:pk>/graphs', ConferenceGraphView.as_view(), name='conference-graphs'),

--- a/app/views/conference_duration_summary_view.py
+++ b/app/views/conference_duration_summary_view.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import Case, Count, IntegerField, When
 
 from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..summary_cache import cached_json
 from ..utils import JSONHttpResponse
 from ..models.conference import Conference
 from .generic_view import GenericView
@@ -56,35 +57,37 @@ class ConferenceDurationSummaryView(GenericView):
             except ValueError:
                 raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        whens = []
-        for i, b in enumerate(BUCKETS):
-            lo, hi = b['min_sec'], b['max_sec']
-            if hi is None:
-                whens.append(When(duration__gte=lo, then=i))
-            elif lo == 0:
-                whens.append(When(duration__lt=hi, then=i))
-            else:
-                whens.append(When(duration__gte=lo, duration__lt=hi, then=i))
+        def compute():
+            whens = []
+            for i, b in enumerate(BUCKETS):
+                lo, hi = b['min_sec'], b['max_sec']
+                if hi is None:
+                    whens.append(When(duration__gte=lo, then=i))
+                elif lo == 0:
+                    whens.append(When(duration__lt=hi, then=i))
+                else:
+                    whens.append(When(duration__gte=lo, duration__lt=hi, then=i))
 
-        try:
-            rows = (Conference.objects
-                .filter(**filters)
-                .annotate(bucket=Case(*whens, output_field=IntegerField()))
-                .values('bucket')
-                .annotate(count=Count('id'))
-                .order_by('bucket'))
-        except ValidationError:
-            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+            try:
+                rows = (Conference.objects
+                    .filter(**filters)
+                    .annotate(bucket=Case(*whens, output_field=IntegerField()))
+                    .values('bucket')
+                    .annotate(count=Count('id'))
+                    .order_by('bucket'))
+            except ValidationError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        counts_by_bucket = {r['bucket']: r['count'] for r in rows if r['bucket'] is not None}
-        data = [
-            {
-                'range': b['title'],
-                'min_sec': b['min_sec'],
-                'max_sec': b['max_sec'],
-                'count': counts_by_bucket.get(i, 0),
-            }
-            for i, b in enumerate(BUCKETS)
-        ]
+            counts_by_bucket = {r['bucket']: r['count'] for r in rows if r['bucket'] is not None}
+            return {'data': [
+                {
+                    'range': b['title'],
+                    'min_sec': b['min_sec'],
+                    'max_sec': b['max_sec'],
+                    'count': counts_by_bucket.get(i, 0),
+                }
+                for i, b in enumerate(BUCKETS)
+            ]}
 
-        return JSONHttpResponse({'data': data})
+        payload, _ = cached_json('conferences.duration_summary', request, compute)
+        return JSONHttpResponse(payload)

--- a/app/views/conference_duration_summary_view.py
+++ b/app/views/conference_duration_summary_view.py
@@ -1,0 +1,90 @@
+import datetime
+
+from django.core.exceptions import ValidationError
+from django.db.models import Case, Count, IntegerField, When
+
+from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..utils import JSONHttpResponse
+from ..models.conference import Conference
+from .generic_view import GenericView
+
+
+BUCKETS = [
+    {'title': '< 1 m',    'min_sec': 0,    'max_sec': 60},
+    {'title': '1 - 3 m',  'min_sec': 60,   'max_sec': 180},
+    {'title': '3 - 5 m',  'min_sec': 180,  'max_sec': 300},
+    {'title': '5 - 10 m', 'min_sec': 300,  'max_sec': 600},
+    {'title': '10 - 15 m','min_sec': 600,  'max_sec': 900},
+    {'title': '15 - 20 m','min_sec': 900,  'max_sec': 1200},
+    {'title': '20 - 25 m','min_sec': 1200, 'max_sec': 1500},
+    {'title': '25 - 30 m','min_sec': 1500, 'max_sec': 1800},
+    {'title': '30 - 40 m','min_sec': 1800, 'max_sec': 2400},
+    {'title': '40 - 50 m','min_sec': 2400, 'max_sec': 3000},
+    {'title': '50 - 60 m','min_sec': 3000, 'max_sec': 3600},
+    {'title': '> 60 m',   'min_sec': 3600, 'max_sec': None},
+]
+
+
+def _parse_iso(value):
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    return datetime.datetime.fromisoformat(value)
+
+
+class ConferenceDurationSummaryView(GenericView):
+    """Returns conference count bucketed by duration range."""
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {'app_id': app_id, 'is_active': True}
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        whens = []
+        for i, b in enumerate(BUCKETS):
+            lo, hi = b['min_sec'], b['max_sec']
+            if hi is None:
+                whens.append(When(duration__gte=lo, then=i))
+            elif lo == 0:
+                whens.append(When(duration__lt=hi, then=i))
+            else:
+                whens.append(When(duration__gte=lo, duration__lt=hi, then=i))
+
+        try:
+            rows = (Conference.objects
+                .filter(**filters)
+                .annotate(bucket=Case(*whens, output_field=IntegerField()))
+                .values('bucket')
+                .annotate(count=Count('id'))
+                .order_by('bucket'))
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        counts_by_bucket = {r['bucket']: r['count'] for r in rows if r['bucket'] is not None}
+        data = [
+            {
+                'range': b['title'],
+                'min_sec': b['min_sec'],
+                'max_sec': b['max_sec'],
+                'count': counts_by_bucket.get(i, 0),
+            }
+            for i, b in enumerate(BUCKETS)
+        ]
+
+        return JSONHttpResponse({'data': data})

--- a/app/views/conference_participant_count_summary_view.py
+++ b/app/views/conference_participant_count_summary_view.py
@@ -1,0 +1,77 @@
+import datetime
+from collections import Counter
+
+from django.core.exceptions import ValidationError
+from django.db.models import Count, IntegerField, OuterRef, Subquery
+
+from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..utils import JSONHttpResponse
+from ..models.conference import Conference
+from ..models.participant import Participant
+from .generic_view import GenericView
+
+
+def _parse_iso(value):
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    return datetime.datetime.fromisoformat(value)
+
+
+class ConferenceParticipantCountSummaryView(GenericView):
+    """
+    Returns the distribution of conferences grouped by how many participants
+    they had. Used by the Number-of-participants pie chart.
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {'app_id': app_id, 'is_active': True}
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        try:
+            per_conf = (Conference.objects
+                .filter(**filters)
+                .annotate(
+                    participants_count=Subquery(
+                        Participant.objects.filter(
+                            conferences=OuterRef('pk'),
+                            is_active=True,
+                        ).order_by().values('conferences').annotate(
+                            cnt=Count('id', distinct=True)
+                        ).values('cnt')[:1],
+                        output_field=IntegerField(),
+                    ),
+                )
+                .values_list('participants_count', flat=True))
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        distribution = Counter()
+        total = 0
+        for count in per_conf:
+            distribution[count or 0] += 1
+            total += 1
+
+        data = [
+            {'participants': n, 'conferences': c}
+            for n, c in sorted(distribution.items())
+        ]
+
+        return JSONHttpResponse({'data': data, 'total_conferences': total})

--- a/app/views/conference_participant_count_summary_view.py
+++ b/app/views/conference_participant_count_summary_view.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import Count, IntegerField, OuterRef, Subquery
 
 from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..summary_cache import cached_json
 from ..utils import JSONHttpResponse
 from ..models.conference import Conference
 from ..models.participant import Participant
@@ -45,33 +46,38 @@ class ConferenceParticipantCountSummaryView(GenericView):
             except ValueError:
                 raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        try:
-            per_conf = (Conference.objects
-                .filter(**filters)
-                .annotate(
-                    participants_count=Subquery(
-                        Participant.objects.filter(
-                            conferences=OuterRef('pk'),
-                            is_active=True,
-                        ).order_by().values('conferences').annotate(
-                            cnt=Count('id', distinct=True)
-                        ).values('cnt')[:1],
-                        output_field=IntegerField(),
-                    ),
-                )
-                .values_list('participants_count', flat=True))
-        except ValidationError:
-            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+        def compute():
+            try:
+                per_conf = (Conference.objects
+                    .filter(**filters)
+                    .annotate(
+                        participants_count=Subquery(
+                            Participant.objects.filter(
+                                conferences=OuterRef('pk'),
+                                is_active=True,
+                            ).order_by().values('conferences').annotate(
+                                cnt=Count('id', distinct=True)
+                            ).values('cnt')[:1],
+                            output_field=IntegerField(),
+                        ),
+                    )
+                    .values_list('participants_count', flat=True))
+            except ValidationError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        distribution = Counter()
-        total = 0
-        for count in per_conf:
-            distribution[count or 0] += 1
-            total += 1
+            distribution = Counter()
+            total = 0
+            for count in per_conf:
+                distribution[count or 0] += 1
+                total += 1
 
-        data = [
-            {'participants': n, 'conferences': c}
-            for n, c in sorted(distribution.items())
-        ]
+            return {
+                'data': [
+                    {'participants': n, 'conferences': c}
+                    for n, c in sorted(distribution.items())
+                ],
+                'total_conferences': total,
+            }
 
-        return JSONHttpResponse({'data': data, 'total_conferences': total})
+        payload, _ = cached_json('conferences.participant_count_summary', request, compute)
+        return JSONHttpResponse(payload)

--- a/app/views/conference_summary_view.py
+++ b/app/views/conference_summary_view.py
@@ -6,6 +6,7 @@ from django.db.models import Case, CharField, Count, Exists, OuterRef, Value, Wh
 from django.db.models.functions import TruncDate
 
 from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..summary_cache import cached_json
 from ..utils import JSONHttpResponse
 from ..models.conference import Conference
 from ..models.issue import Issue
@@ -48,48 +49,50 @@ class ConferenceSummaryView(GenericView):
             except ValueError:
                 raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        try:
-            rows = (Conference.objects
-                .filter(**filters)
-                .annotate(
-                    day=TruncDate('created_at'),
-                    has_error=Exists(
-                        Issue.objects.filter(conference=OuterRef('pk'), type='e', is_active=True)
-                    ),
-                    has_warning=Exists(
-                        Issue.objects.filter(conference=OuterRef('pk'), type='w', is_active=True)
-                    ),
-                )
-                .annotate(
-                    status=Case(
-                        When(ongoing=True, then=Value('ongoing')),
-                        When(has_error=True, then=Value('error')),
-                        When(has_warning=True, then=Value('warning')),
-                        default=Value('success'),
-                        output_field=CharField(),
-                    ),
-                )
-                .values('day', 'status')
-                .annotate(count=Count('id'))
-                .order_by('day'))
-        except ValidationError:
-            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+        def compute():
+            try:
+                rows = (Conference.objects
+                    .filter(**filters)
+                    .annotate(
+                        day=TruncDate('created_at'),
+                        has_error=Exists(
+                            Issue.objects.filter(conference=OuterRef('pk'), type='e', is_active=True)
+                        ),
+                        has_warning=Exists(
+                            Issue.objects.filter(conference=OuterRef('pk'), type='w', is_active=True)
+                        ),
+                    )
+                    .annotate(
+                        status=Case(
+                            When(ongoing=True, then=Value('ongoing')),
+                            When(has_error=True, then=Value('error')),
+                            When(has_warning=True, then=Value('warning')),
+                            default=Value('success'),
+                            output_field=CharField(),
+                        ),
+                    )
+                    .values('day', 'status')
+                    .annotate(count=Count('id'))
+                    .order_by('day'))
+            except ValidationError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        buckets = defaultdict(lambda: {'success': 0, 'warning': 0, 'error': 0, 'ongoing': 0})
-        for row in rows:
-            day_key = row['day'].isoformat() if row['day'] else None
-            buckets[day_key][row['status']] = row['count']
+            buckets = defaultdict(lambda: {'success': 0, 'warning': 0, 'error': 0, 'ongoing': 0})
+            for row in rows:
+                day_key = row['day'].isoformat() if row['day'] else None
+                buckets[day_key][row['status']] = row['count']
 
-        data = [
-            {
-                'date': day,
-                'success': counts['success'],
-                'warning': counts['warning'],
-                'error': counts['error'],
-                'ongoing': counts['ongoing'],
-                'total': counts['success'] + counts['warning'] + counts['error'] + counts['ongoing'],
-            }
-            for day, counts in sorted(buckets.items(), key=lambda x: x[0] or '')
-        ]
+            return {'data': [
+                {
+                    'date': day,
+                    'success': counts['success'],
+                    'warning': counts['warning'],
+                    'error': counts['error'],
+                    'ongoing': counts['ongoing'],
+                    'total': counts['success'] + counts['warning'] + counts['error'] + counts['ongoing'],
+                }
+                for day, counts in sorted(buckets.items(), key=lambda x: x[0] or '')
+            ]}
 
-        return JSONHttpResponse({'data': data})
+        payload, _ = cached_json('conferences.summary', request, compute)
+        return JSONHttpResponse(payload)

--- a/app/views/conference_view.py
+++ b/app/views/conference_view.py
@@ -39,6 +39,12 @@ class ConferencesView(GenericView):
             if request.GET.get(rkey):
                 filters[key] = request.GET.get(rkey)
 
+        ids_param = request.GET.get('conference_ids')
+        if ids_param:
+            ids = [i for i in ids_param.split(',') if i]
+            if ids:
+                filters['id__in'] = ids
+
         if not filters:
             raise PMError(status=400, app_error=MISSING_PARAMETERS)
 

--- a/app/views/conference_view.py
+++ b/app/views/conference_view.py
@@ -30,6 +30,9 @@ class ConferencesView(GenericView):
             'created_at__gte': 'created_at_gte',
             'created_at__lt': 'created_at_lt',
             'created_at__lte': 'created_at_lte',
+            'duration__gte': 'duration_gte',
+            'duration__lt': 'duration_lt',
+            'issues__code': 'issue_code',
         }
 
         for key, rkey in allowed_filters.items():

--- a/app/views/conference_view.py
+++ b/app/views/conference_view.py
@@ -39,6 +39,10 @@ class ConferencesView(GenericView):
             if request.GET.get(rkey):
                 filters[key] = request.GET.get(rkey)
 
+        filter_by_issue_code = bool(request.GET.get('issue_code'))
+        if filter_by_issue_code:
+            filters['issues__is_active'] = True
+
         ids_param = request.GET.get('conference_ids')
         if ids_param:
             ids = [i for i in ids_param.split(',') if i]
@@ -69,6 +73,8 @@ class ConferencesView(GenericView):
                     output_field=IntegerField(),
                 ),
             )
+            if filter_by_issue_code:
+                objs = objs.distinct()
         except ValidationError:
             raise PMError(status=400, app_error=INVALID_PARAMETERS)
 

--- a/app/views/connection_summary_view.py
+++ b/app/views/connection_summary_view.py
@@ -5,6 +5,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import Case, Count, IntegerField, When
 
 from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..summary_cache import cached_json
 from ..utils import JSONHttpResponse
 from ..models.connection import Connection, TYPE_OF_CONNECTIONS_ENUM
 from .generic_view import GenericView
@@ -81,34 +82,37 @@ class ConnectionSummaryView(GenericView):
             except ValueError:
                 raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        relay_code = TYPE_OF_CONNECTIONS_ENUM['relay']
+        def compute():
+            relay_code = TYPE_OF_CONNECTIONS_ENUM['relay']
+            try:
+                rows = (Connection.objects
+                    .filter(**filters)
+                    .exclude(type__isnull=True)
+                    .annotate(
+                        group=Case(
+                            When(type=relay_code, then=1),
+                            default=0,
+                            output_field=IntegerField(),
+                        ),
+                    )
+                    .values('group')
+                    .annotate(count=Count('id')))
+            except ValidationError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        try:
-            rows = (Connection.objects
-                .filter(**filters)
-                .exclude(type__isnull=True)
-                .annotate(
-                    group=Case(
-                        When(type=relay_code, then=1),
-                        default=0,
-                        output_field=IntegerField(),
-                    ),
-                )
-                .values('group')
-                .annotate(count=Count('id')))
-        except ValidationError:
-            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+            counts = {0: 0, 1: 0}
+            for row in rows:
+                counts[row['group']] = row['count']
 
-        counts = {0: 0, 1: 0}
-        for row in rows:
-            counts[row['group']] = row['count']
+            return {
+                'data': [
+                    {'name': 'Direct', 'count': counts[0]},
+                    {'name': 'Relayed', 'count': counts[1]},
+                ],
+            }
 
-        return JSONHttpResponse({
-            'data': [
-                {'name': 'Direct', 'count': counts[0]},
-                {'name': 'Relayed', 'count': counts[1]},
-            ],
-        })
+        payload, _ = cached_json('connections.summary', request, compute)
+        return JSONHttpResponse(payload)
 
 
 class ConnectionSetupTimeSummaryView(GenericView):
@@ -143,45 +147,48 @@ class ConnectionSetupTimeSummaryView(GenericView):
             except ValueError:
                 raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        counters = Counter()
-        conferences_per_bucket = {i: set() for i in range(len(SETUP_TIME_BUCKETS))}
+        def compute():
+            counters = Counter()
+            conferences_per_bucket = {i: set() for i in range(len(SETUP_TIME_BUCKETS))}
 
-        try:
-            rows = Connection.objects.filter(**filters).values_list(
-                'connection_info', 'conference_id'
-            )
-            for info, conf_id in rows:
-                if not info:
-                    continue
-                negotiations = info.get('negotiations') or []
-                if not negotiations:
-                    continue
-                first = negotiations[0]
-                if first.get('status') != 'connected':
-                    continue
-                start = _parse_time(first.get('start_time'))
-                end = _parse_time(first.get('end_time'))
-                if not start or not end:
-                    continue
-                ms = (end - start).total_seconds() * 1000
-                if ms < 0:
-                    continue
-                idx = _bucket_for(ms)
-                if idx is None:
-                    continue
-                counters[idx] += 1
-                conferences_per_bucket[idx].add(str(conf_id))
-        except ValidationError:
-            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+            try:
+                rows = Connection.objects.filter(**filters).values_list(
+                    'connection_info', 'conference_id'
+                )
+                for info, conf_id in rows:
+                    if not info:
+                        continue
+                    negotiations = info.get('negotiations') or []
+                    if not negotiations:
+                        continue
+                    first = negotiations[0]
+                    if first.get('status') != 'connected':
+                        continue
+                    start = _parse_time(first.get('start_time'))
+                    end = _parse_time(first.get('end_time'))
+                    if not start or not end:
+                        continue
+                    ms = (end - start).total_seconds() * 1000
+                    if ms < 0:
+                        continue
+                    idx = _bucket_for(ms)
+                    if idx is None:
+                        continue
+                    counters[idx] += 1
+                    conferences_per_bucket[idx].add(str(conf_id))
+            except ValidationError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        data = []
-        for i, b in enumerate(SETUP_TIME_BUCKETS):
-            data.append({
-                'range': b['title'],
-                'min_ms': b['min_ms'],
-                'max_ms': b['max_ms'],
-                'count': counters.get(i, 0),
-                'conference_ids': list(conferences_per_bucket[i]),
-            })
+            data = []
+            for i, b in enumerate(SETUP_TIME_BUCKETS):
+                data.append({
+                    'range': b['title'],
+                    'min_ms': b['min_ms'],
+                    'max_ms': b['max_ms'],
+                    'count': counters.get(i, 0),
+                    'conference_ids': list(conferences_per_bucket[i]),
+                })
+            return {'data': data}
 
-        return JSONHttpResponse({'data': data})
+        payload, _ = cached_json('connections.setup_time_summary', request, compute)
+        return JSONHttpResponse(payload)

--- a/app/views/connection_summary_view.py
+++ b/app/views/connection_summary_view.py
@@ -1,0 +1,187 @@
+import datetime
+from collections import Counter
+
+from django.core.exceptions import ValidationError
+from django.db.models import Case, Count, IntegerField, When
+
+from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..utils import JSONHttpResponse
+from ..models.connection import Connection, TYPE_OF_CONNECTIONS_ENUM
+from .generic_view import GenericView
+
+
+SETUP_TIME_BUCKETS = [
+    {'title': '< 250 ms',       'min_ms': 0,    'max_ms': 250},
+    {'title': '250 - 500 ms',   'min_ms': 250,  'max_ms': 500},
+    {'title': '500 - 750 ms',   'min_ms': 500,  'max_ms': 750},
+    {'title': '750 - 1000 ms',  'min_ms': 750,  'max_ms': 1000},
+    {'title': '1000 - 1500 ms', 'min_ms': 1000, 'max_ms': 1500},
+    {'title': '1500 - 2000 ms', 'min_ms': 1500, 'max_ms': 2000},
+    {'title': '2000 - 2500 ms', 'min_ms': 2000, 'max_ms': 2500},
+    {'title': '2500 - 3000 ms', 'min_ms': 2500, 'max_ms': 3000},
+    {'title': '3000 - 4000 ms', 'min_ms': 3000, 'max_ms': 4000},
+    {'title': '4000 - 5000 ms', 'min_ms': 4000, 'max_ms': 5000},
+    {'title': '> 5000 ms',      'min_ms': 5000, 'max_ms': None},
+]
+
+
+def _parse_iso(value):
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    return datetime.datetime.fromisoformat(value)
+
+
+def _parse_time(value):
+    if not value:
+        return None
+    try:
+        return _parse_iso(value) if isinstance(value, str) else value
+    except Exception:
+        return None
+
+
+def _bucket_for(ms):
+    for i, b in enumerate(SETUP_TIME_BUCKETS):
+        if b['max_ms'] is None:
+            if ms >= b['min_ms']:
+                return i
+        elif b['min_ms'] <= ms < b['max_ms']:
+            return i
+    return None
+
+
+class ConnectionSummaryView(GenericView):
+    """
+    Returns connection counts grouped by type — relay (TURN) vs direct.
+    Replaces the Relayed-connections pie chart's client-side aggregation.
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {
+            'conference__app_id': app_id,
+            'is_active': True,
+        }
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        relay_code = TYPE_OF_CONNECTIONS_ENUM['relay']
+
+        try:
+            rows = (Connection.objects
+                .filter(**filters)
+                .exclude(type__isnull=True)
+                .annotate(
+                    group=Case(
+                        When(type=relay_code, then=1),
+                        default=0,
+                        output_field=IntegerField(),
+                    ),
+                )
+                .values('group')
+                .annotate(count=Count('id')))
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        counts = {0: 0, 1: 0}
+        for row in rows:
+            counts[row['group']] = row['count']
+
+        return JSONHttpResponse({
+            'data': [
+                {'name': 'Direct', 'count': counts[0]},
+                {'name': 'Relayed', 'count': counts[1]},
+            ],
+        })
+
+
+class ConnectionSetupTimeSummaryView(GenericView):
+    """
+    Returns counts of connections bucketed by initial-negotiation setup
+    time (end_time - start_time on the first 'connected' negotiation
+    in connection_info.negotiations).
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {
+            'conference__app_id': app_id,
+            'is_active': True,
+        }
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        counters = Counter()
+        conferences_per_bucket = {i: set() for i in range(len(SETUP_TIME_BUCKETS))}
+
+        try:
+            rows = Connection.objects.filter(**filters).values_list(
+                'connection_info', 'conference_id'
+            )
+            for info, conf_id in rows:
+                if not info:
+                    continue
+                negotiations = info.get('negotiations') or []
+                if not negotiations:
+                    continue
+                first = negotiations[0]
+                if first.get('status') != 'connected':
+                    continue
+                start = _parse_time(first.get('start_time'))
+                end = _parse_time(first.get('end_time'))
+                if not start or not end:
+                    continue
+                ms = (end - start).total_seconds() * 1000
+                if ms < 0:
+                    continue
+                idx = _bucket_for(ms)
+                if idx is None:
+                    continue
+                counters[idx] += 1
+                conferences_per_bucket[idx].add(str(conf_id))
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        data = []
+        for i, b in enumerate(SETUP_TIME_BUCKETS):
+            data.append({
+                'range': b['title'],
+                'min_ms': b['min_ms'],
+                'max_ms': b['max_ms'],
+                'count': counters.get(i, 0),
+                'conference_ids': list(conferences_per_bucket[i]),
+            })
+
+        return JSONHttpResponse({'data': data})

--- a/app/views/issue_summary_view.py
+++ b/app/views/issue_summary_view.py
@@ -111,7 +111,7 @@ class GetUserMediaSummaryView(GenericView):
             try:
                 issues = Issue.objects.filter(**filters).values_list('data', flat=True)
                 for data in issues:
-                    if not data:
+                    if not data or not isinstance(data, dict):
                         continue
                     name = data.get('name') or 'Unknown'
                     name_counter[name] += 1

--- a/app/views/issue_summary_view.py
+++ b/app/views/issue_summary_view.py
@@ -1,0 +1,128 @@
+import datetime
+
+from django.core.exceptions import ValidationError
+from django.db.models import Count
+
+from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..utils import JSONHttpResponse
+from ..models.issue import Issue, ISSUES
+from .generic_view import GenericView
+
+
+def _parse_iso(value):
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    return datetime.datetime.fromisoformat(value)
+
+
+class IssueSummaryView(GenericView):
+    """
+    Returns issue counts grouped by code. Used by the Most-common-issues chart.
+    Replaces downloading all issues (73 MB+ on production) to aggregate in
+    the browser.
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {
+            'conference__app_id': app_id,
+            'is_active': True,
+        }
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        try:
+            rows = (Issue.objects
+                .filter(**filters)
+                .values('code')
+                .annotate(count=Count('id'))
+                .order_by('-count'))
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        data = [
+            {
+                'code': r['code'],
+                'title': ISSUES.get(r['code'], {}).get('title', r['code']),
+                'count': r['count'],
+            }
+            for r in rows
+        ]
+
+        return JSONHttpResponse({'data': data})
+
+
+class GetUserMediaSummaryView(GenericView):
+    """
+    Returns counts of getusermedia_error issues grouped by the error's `name`
+    field inside the JSON data. Used by the GUM (getUserMedia errors) chart.
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {
+            'conference__app_id': app_id,
+            'code': 'getusermedia_error',
+            'is_active': True,
+        }
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        from collections import Counter
+        name_counter = Counter()
+        message_by_name = {}
+
+        try:
+            issues = Issue.objects.filter(**filters).values_list('data', flat=True)
+            for data in issues:
+                if not data:
+                    continue
+                name = data.get('name') or 'Unknown'
+                name_counter[name] += 1
+                if name not in message_by_name and data.get('message'):
+                    message_by_name[name] = data['message']
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        data = [
+            {
+                'name': name,
+                'message': message_by_name.get(name, ''),
+                'count': count,
+            }
+            for name, count in name_counter.most_common()
+        ]
+
+        return JSONHttpResponse({'data': data, 'total': sum(name_counter.values())})

--- a/app/views/issue_summary_view.py
+++ b/app/views/issue_summary_view.py
@@ -4,6 +4,7 @@ from django.core.exceptions import ValidationError
 from django.db.models import Count
 
 from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..summary_cache import cached_json
 from ..utils import JSONHttpResponse
 from ..models.issue import Issue, ISSUES
 from .generic_view import GenericView
@@ -47,25 +48,27 @@ class IssueSummaryView(GenericView):
             except ValueError:
                 raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        try:
-            rows = (Issue.objects
-                .filter(**filters)
-                .values('code')
-                .annotate(count=Count('id'))
-                .order_by('-count'))
-        except ValidationError:
-            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+        def compute():
+            try:
+                rows = (Issue.objects
+                    .filter(**filters)
+                    .values('code')
+                    .annotate(count=Count('id'))
+                    .order_by('-count'))
+            except ValidationError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        data = [
-            {
-                'code': r['code'],
-                'title': ISSUES.get(r['code'], {}).get('title', r['code']),
-                'count': r['count'],
-            }
-            for r in rows
-        ]
+            return {'data': [
+                {
+                    'code': r['code'],
+                    'title': ISSUES.get(r['code'], {}).get('title', r['code']),
+                    'count': r['count'],
+                }
+                for r in rows
+            ]}
 
-        return JSONHttpResponse({'data': data})
+        payload, _ = cached_json('issues.summary', request, compute)
+        return JSONHttpResponse(payload)
 
 
 class GetUserMediaSummaryView(GenericView):
@@ -100,29 +103,34 @@ class GetUserMediaSummaryView(GenericView):
             except ValueError:
                 raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        from collections import Counter
-        name_counter = Counter()
-        message_by_name = {}
+        def compute():
+            from collections import Counter
+            name_counter = Counter()
+            message_by_name = {}
 
-        try:
-            issues = Issue.objects.filter(**filters).values_list('data', flat=True)
-            for data in issues:
-                if not data:
-                    continue
-                name = data.get('name') or 'Unknown'
-                name_counter[name] += 1
-                if name not in message_by_name and data.get('message'):
-                    message_by_name[name] = data['message']
-        except ValidationError:
-            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+            try:
+                issues = Issue.objects.filter(**filters).values_list('data', flat=True)
+                for data in issues:
+                    if not data:
+                        continue
+                    name = data.get('name') or 'Unknown'
+                    name_counter[name] += 1
+                    if name not in message_by_name and data.get('message'):
+                        message_by_name[name] = data['message']
+            except ValidationError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        data = [
-            {
-                'name': name,
-                'message': message_by_name.get(name, ''),
-                'count': count,
+            return {
+                'data': [
+                    {
+                        'name': name,
+                        'message': message_by_name.get(name, ''),
+                        'count': count,
+                    }
+                    for name, count in name_counter.most_common()
+                ],
+                'total': sum(name_counter.values()),
             }
-            for name, count in name_counter.most_common()
-        ]
 
-        return JSONHttpResponse({'data': data, 'total': sum(name_counter.values())})
+        payload, _ = cached_json('issues.gum_summary', request, compute)
+        return JSONHttpResponse(payload)

--- a/app/views/session_summary_view.py
+++ b/app/views/session_summary_view.py
@@ -4,6 +4,7 @@ from collections import Counter, defaultdict
 from django.core.exceptions import ValidationError
 
 from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..summary_cache import cached_json
 from ..utils import JSONHttpResponse
 from ..models.session import Session
 from .generic_view import GenericView
@@ -49,59 +50,63 @@ class SessionSummaryView(GenericView):
             except ValueError:
                 raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        browsers = Counter()
-        oses = Counter()
-        countries = Counter()
-        cities = {}  # city name -> {lat, lon, count}
+        def compute():
+            browsers = Counter()
+            oses = Counter()
+            countries = Counter()
+            cities = {}  # city name -> {lat, lon, count}
 
-        try:
-            rows = Session.objects.filter(**filters).values_list('platform', 'geo_ip')
-            for platform, geo_ip in rows:
-                if platform:
-                    browser = (platform.get('browser') or {}).get('name') or 'Unknown'
-                    os_name = (platform.get('os') or {}).get('name') or 'Unknown'
-                    browsers[browser] += 1
-                    oses[os_name] += 1
+            try:
+                rows = Session.objects.filter(**filters).values_list('platform', 'geo_ip')
+                for platform, geo_ip in rows:
+                    if platform:
+                        browser = (platform.get('browser') or {}).get('name') or 'Unknown'
+                        os_name = (platform.get('os') or {}).get('name') or 'Unknown'
+                        browsers[browser] += 1
+                        oses[os_name] += 1
 
-                if geo_ip:
-                    country_code = geo_ip.get('country_code')
-                    if country_code:
-                        countries[country_code] += 1
+                    if geo_ip:
+                        country_code = geo_ip.get('country_code')
+                        if country_code:
+                            countries[country_code] += 1
 
-                    city = geo_ip.get('city')
-                    lat = geo_ip.get('latitude')
-                    lon = geo_ip.get('longitude')
-                    if city and lat is not None and lon is not None:
-                        try:
-                            lat_f = float(lat)
-                            lon_f = float(lon)
-                            if lat_f or lon_f:
-                                if city in cities:
-                                    cities[city]['count'] += 1
-                                else:
-                                    cities[city] = {
-                                        'city': city,
-                                        'latitude': lat_f,
-                                        'longitude': lon_f,
-                                        'count': 1,
-                                    }
-                        except (TypeError, ValueError):
-                            pass
-        except ValidationError:
-            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+                        city = geo_ip.get('city')
+                        lat = geo_ip.get('latitude')
+                        lon = geo_ip.get('longitude')
+                        if city and lat is not None and lon is not None:
+                            try:
+                                lat_f = float(lat)
+                                lon_f = float(lon)
+                                if lat_f or lon_f:
+                                    if city in cities:
+                                        cities[city]['count'] += 1
+                                    else:
+                                        cities[city] = {
+                                            'city': city,
+                                            'latitude': lat_f,
+                                            'longitude': lon_f,
+                                            'count': 1,
+                                        }
+                            except (TypeError, ValueError):
+                                pass
+            except ValidationError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
 
-        return JSONHttpResponse({
-            'browsers': [
-                {'name': k, 'count': v}
-                for k, v in browsers.most_common()
-            ],
-            'os': [
-                {'name': k, 'count': v}
-                for k, v in oses.most_common()
-            ],
-            'countries': [
-                {'code': k, 'count': v}
-                for k, v in countries.most_common()
-            ],
-            'cities': list(cities.values()),
-        })
+            return {
+                'browsers': [
+                    {'name': k, 'count': v}
+                    for k, v in browsers.most_common()
+                ],
+                'os': [
+                    {'name': k, 'count': v}
+                    for k, v in oses.most_common()
+                ],
+                'countries': [
+                    {'code': k, 'count': v}
+                    for k, v in countries.most_common()
+                ],
+                'cities': list(cities.values()),
+            }
+
+        payload, _ = cached_json('sessions.summary', request, compute)
+        return JSONHttpResponse(payload)

--- a/app/views/session_summary_view.py
+++ b/app/views/session_summary_view.py
@@ -1,0 +1,107 @@
+import datetime
+from collections import Counter, defaultdict
+
+from django.core.exceptions import ValidationError
+
+from ..errors import INVALID_PARAMETERS, MISSING_PARAMETERS, PMError
+from ..utils import JSONHttpResponse
+from ..models.session import Session
+from .generic_view import GenericView
+
+
+def _parse_iso(value):
+    if value.endswith('Z'):
+        value = value[:-1] + '+00:00'
+    return datetime.datetime.fromisoformat(value)
+
+
+class SessionSummaryView(GenericView):
+    """
+    Returns session counts aggregated by browser, OS, and country.
+    Replaces downloading all sessions to aggregate client-side in the
+    Browsers, Operating Systems, and Map charts.
+
+    Also returns geo points (lat/lon) for rendering on the map chart.
+    """
+
+    @classmethod
+    def get(cls, request):
+        app_id = request.GET.get('appId')
+        if not app_id:
+            raise PMError(status=400, app_error=MISSING_PARAMETERS)
+
+        filters = {
+            'conference__app_id': app_id,
+            'is_active': True,
+        }
+
+        created_at_gte = request.GET.get('created_at_gte')
+        if created_at_gte:
+            try:
+                filters['created_at__gte'] = _parse_iso(created_at_gte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        created_at_lte = request.GET.get('created_at_lte')
+        if created_at_lte:
+            try:
+                filters['created_at__lte'] = _parse_iso(created_at_lte)
+            except ValueError:
+                raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        browsers = Counter()
+        oses = Counter()
+        countries = Counter()
+        cities = {}  # city name -> {lat, lon, count}
+
+        try:
+            rows = Session.objects.filter(**filters).values_list('platform', 'geo_ip')
+            for platform, geo_ip in rows:
+                if platform:
+                    browser = (platform.get('browser') or {}).get('name') or 'Unknown'
+                    os_name = (platform.get('os') or {}).get('name') or 'Unknown'
+                    browsers[browser] += 1
+                    oses[os_name] += 1
+
+                if geo_ip:
+                    country_code = geo_ip.get('country_code')
+                    if country_code:
+                        countries[country_code] += 1
+
+                    city = geo_ip.get('city')
+                    lat = geo_ip.get('latitude')
+                    lon = geo_ip.get('longitude')
+                    if city and lat is not None and lon is not None:
+                        try:
+                            lat_f = float(lat)
+                            lon_f = float(lon)
+                            if lat_f or lon_f:
+                                if city in cities:
+                                    cities[city]['count'] += 1
+                                else:
+                                    cities[city] = {
+                                        'city': city,
+                                        'latitude': lat_f,
+                                        'longitude': lon_f,
+                                        'count': 1,
+                                    }
+                        except (TypeError, ValueError):
+                            pass
+        except ValidationError:
+            raise PMError(status=400, app_error=INVALID_PARAMETERS)
+
+        return JSONHttpResponse({
+            'browsers': [
+                {'name': k, 'count': v}
+                for k, v in browsers.most_common()
+            ],
+            'os': [
+                {'name': k, 'count': v}
+                for k, v in oses.most_common()
+            ],
+            'countries': [
+                {'code': k, 'count': v}
+                for k, v in countries.most_common()
+            ],
+            'cities': list(cities.values()),
+        })


### PR DESCRIPTION
## Summary
**Stacked on top of #26 and #27** — PR diff will show all Phase 2-5 + Phase C commits until those upstream PRs merge, then rebase down to just the cache commit (\`6b2a3a6\`).

Phases 0-5 moved dashboard aggregation to SQL. Phase C caches the results: one Redis entry per (endpoint + filter params), 60s TTL, pre-warmed so first visitors don't pay cold-query cost.

- \`app/summary_cache.py\` — \`cached_json(endpoint, request, compute)\` wraps any summary view. Reads Redis; on miss, runs the compute closure and writes back with 60s TTL. Uses existing Django-redis cache backend with \`IGNORE_EXCEPTIONS=True\`, so a Redis outage degrades to the pre-cache behavior, never breaks.
- All 8 summary views refactored to pass their compute bodies through the helper. No change to JSON shape or query logic.
- \`manage.py prewarm_summaries\` — iterates apps with recent traffic and warms every summary view for the 30-day window the dashboard requests by default. Intended as an ECS scheduled task at ~30s cadence.

## Local benchmark (7-day Production clone, ~18k conferences / 38k sessions / 38k connections)

| endpoint | cold | warm | speedup |
|---|---:|---:|---:|
| conferences/summary | 391ms | 12ms | 33× |
| sessions/summary | 748ms | 11ms | 68× |
| connections/setup-time-summary | 373ms | 11ms | 34× |
| conferences/participant-count-summary | 216ms | 7ms | 31× |
| issues/gum-summary | 107ms | 6ms | 18× |
| connections/summary | 57ms | 6ms | 9.5× |
| issues/summary | 45ms | 86ms | noise |
| conferences/duration-summary | 19ms | 8ms | 2.3× |

Total warm dashboard cost ≈ 150ms across all 8 endpoints (vs ~2s cold).

## Test plan
- [ ] Verify \`/v1/conferences/summary\` returns identical JSON before and after enabling cache
- [ ] Flush redis, hit all 8 endpoints, confirm 8 keys appear at \`:1:summary:*\`
- [ ] Hit the same endpoints again — confirm p99 < 50ms
- [ ] Set \`SUMMARY_CACHE_TTL=5\`, wait 6s, confirm re-query triggers a new compute
- [ ] Kill redis, confirm endpoints still return correct data (just slower)
- [ ] Run \`manage.py prewarm_summaries\` — confirm 8 keys/app written, slow-query log line for any >500ms compute

## Follow-ups (not in this PR)
- Hook \`prewarm_summaries\` into the ECS scheduled task config (infra repo).
- Consider surfacing \`X-Cache: HIT|MISS\` response header for ops visibility.
- Pre-existing: local \`docker-compose\` sets \`REDIS_HOST=redis://127.0.0.1:6379\` which doesn't resolve inside the api container. Added a local override file; worth a one-liner fix in compose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)